### PR TITLE
initial deploy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ juju add-model dev
 # Enable DEBUG logging
 juju model-config logging-config="<root>=INFO;unit=DEBUG"
 # Deploy the charm
-juju deploy ./kratos_ubuntu-*-amd64.charm
+juju deploy ./kratos_ubuntu-*-amd64.charm --trust --resource oci-image=oryd/kratos:v0.10.1
 ```
 
 ## Canonical Contributor Agreement

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -6,3 +6,12 @@ description: |
   Charmed Ory Kratos
 summary: |
   Identity and user management system
+containers:
+  kratos:
+    resource: oci-image
+resources:
+  oci-image:
+    type: oci-image
+    description: Kratos OCI oci-image
+    auto-fetch: true
+    upstream-source: oryd/kratos:v0.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 ops ==1.5.3
+charmed-kubeflow-chisme
+lightkube

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,10 +6,20 @@
 
 """A Juju charm for Ory Kratos."""
 
+import glob
 import logging
+from pathlib import Path
 
+from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
+from charmed_kubeflow_chisme.kubernetes import KubernetesResourceHandler
+from charmed_kubeflow_chisme.pebble import update_layer
+from lightkube import Client
+from lightkube.core.exceptions import ApiError
+from lightkube.resources.apps_v1 import StatefulSet
 from ops.charm import CharmBase
 from ops.main import main
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
+from ops.pebble import Layer, PathError, ProtocolError
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +29,156 @@ class KratosCharm(CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
+        self._container_name = "kratos"
+        self.container = self.unit.get_container(self._container_name)
+
+        self.resource_handler = KubernetesResourceHandler(
+            template_files=self._template_files,
+            context=self._context,
+            field_manager=self.model.app.name,
+        )
+        self.lightkube_client = Client(namespace=self.model.name, field_manager="lightkube")
+
+        self.framework.observe(self.on.install, self._on_install)
+        self.framework.observe(self.on.kratos_pebble_ready, self._on_pebble_ready)
+
+    @property
+    def _template_files(self):
+        src_dir = Path("src/manifests")
+        manifests = [file for file in glob.glob(f"{src_dir}/*.yaml")]
+        return manifests
+
+    @property
+    def _context(self):
+        context = {
+            "app_name": self.model.app.name,
+        }
+        return context
+
+    @property
+    def _pebble_layer(self) -> Layer:
+        pebble_layer = {
+            "summary": "kratos layer",
+            "description": "pebble config layer for kratos",
+            "services": {
+                self._container_name: {
+                    "override": "replace",
+                    "summary": "Kratos Operator layer",
+                    "startup": "enabled",
+                    "command": "kratos serve all --config /etc/config/kratos.yaml",
+                    "environment": {
+                        "DSN": "postgres://username:password@10.152.183.152:5432/postgres",
+                        "COURIER_SMTP_CONNECTION_URI": "smtps://test:test@mailslurper:1025/?skip_ssl_verify=true",
+                    },
+                }
+            },
+            "checks": {
+                "ready": {
+                    "override": "replace",
+                    "http": {"url": "http://localhost:4434/admin/health/ready"},
+                },
+                "alive": {
+                    "override": "replace",
+                    "http": {"url": "http://localhost:4434/admin/health/ready"},
+                },
+            },
+        }
+        return Layer(pebble_layer)
+
+    def _update_kratos_config(self) -> None:
+        """Push configs and identity schema into kratos container."""
+        try:
+            with open("src/config.yaml", encoding="utf-8") as config_file:
+                config = config_file.read()
+                self.container.push("/etc/config/kratos.yaml", config, make_dirs=True)
+            with open("src/identity.default.schema.json", encoding="utf-8") as schema_file:
+                schema = schema_file.read()
+                self.container.push("/etc/config/identity.default.schema.json", schema)
+            logger.info("Pushed configs to kratos container")
+        except (ProtocolError, PathError) as e:
+            logger.error(str(e))
+            self.unit.status = BlockedStatus(str(e))
+
+    def _on_install(self, _) -> None:
+        """Event Handler for install event.
+
+        - push configs
+        - apply service manifests
+        - update pod template to expose 2 ports
+        """
+        self.unit.status = MaintenanceStatus("Configuring/deploying resources")
+
+        if self.container.can_connect():
+            self._update_kratos_config()
+
+        try:
+            self.resource_handler.apply()
+            self.lightkube_client.patch(
+                StatefulSet,
+                self.model.app.name,
+                {
+                    "spec": {
+                        "template": {
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "name": "kratos",
+                                        "ports": [
+                                            {
+                                                "name": "http-admin",
+                                                "containerPort": 4434,
+                                                "protocol": "TCP",
+                                            },
+                                            {
+                                                "name": "http-public",
+                                                "containerPort": 4433,
+                                                "protocol": "TCP",
+                                            },
+                                        ],
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+            )
+
+        except (ApiError, ErrorWithStatus) as e:
+            if isinstance(e, ApiError):
+                logger.error(
+                    f"Applying resources failed with ApiError status code {e.status.code}, error response: {e.response}"
+                )
+                self.unit.status = BlockedStatus(f"ApiError: {e.status.code}")
+            else:
+                logger.info(e.msg)
+                self.unit.status = e.status
+        else:
+            self.unit.status = ActiveStatus()
+
+    def _on_pebble_ready(self, event) -> None:
+        """Event Handler for pebble ready event.
+
+        Do the following if kratos container can be connected:
+        - push configs
+        - update pebble layer.
+        """
+        self.unit.status = MaintenanceStatus("Configuring/deploying resources")
+
+        if self.container.can_connect():
+            self._update_kratos_config()
+            try:
+                update_layer(self._container_name, self.container, self._pebble_layer, logger)
+                self.unit.status = ActiveStatus()
+            except ErrorWithStatus as e:
+                self.model.unit.status = e.status
+                if isinstance(e.status, BlockedStatus):
+                    logger.error(str(e.msg))
+                else:
+                    logger.info(str(e.msg))
+        else:
+            event.defer()
+            logger.info("Cannot connect to Kratos container. Deferring pebble ready event.")
+            self.unit.status = WaitingStatus("Waiting to connect to Kratos container")
 
 
 if __name__ == "__main__":

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -1,0 +1,13 @@
+log:
+  level: trace
+identity:
+  default_schema_id: default
+  schemas:
+    - id: default
+      url: file:///etc/config/identity.default.schema.json
+selfservice:
+  default_browser_return_url: http://127.0.0.1:9999/
+  flows:
+    registration:
+      enabled: true
+      ui_url: http://127.0.0.1:9999/registration

--- a/src/identity.default.schema.json
+++ b/src/identity.default.schema.json
@@ -1,0 +1,33 @@
+{
+  "$id": "https://schemas.ory.sh/presets/kratos/identity.email.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Person",
+  "type": "object",
+  "properties": {
+    "traits": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "format": "email",
+          "title": "E-Mail",
+          "ory.sh/kratos": {
+            "credentials": {
+              "password": {
+                "identifier": true
+              }
+            },
+            "recovery": {
+              "via": "email"
+            },
+            "verification": {
+              "via": "email"
+            }
+          }
+        }
+      },
+      "required": ["email"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/manifests/svc.yaml
+++ b/src/manifests/svc.yaml
@@ -1,0 +1,46 @@
+---
+# Source: https://github.com/ory/k8s/k8s/helm/charts/kratos/templates/service-admin.yaml
+# helm charm v0.25.3
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ app_name }}-admin
+  labels:
+    app.kubernetes.io/component: {{ app_name }}-admin
+    app.kubernetes.io/name: {{ app_name }}
+    app.kubernetes.io/managed-by: juju
+    app.juju.is/created-by: {{ app_name }}
+    operator.juju.is/name: {{ app_name }}
+    operator.juju.is/target: application
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http-admin
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ app_name }}
+---
+# Source: https://github.com/ory/k8s/k8s/helm/charts/kratos/templates/service-public.yaml
+# helm charm v0.25.3
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ app_name }}-public
+  labels:
+    app.kubernetes.io/component: {{ app_name }}-public
+    app.kubernetes.io/name: {{ app_name }}
+    app.kubernetes.io/managed-by: juju
+    app.juju.is/created-by: {{ app_name }}
+    operator.juju.is/name: {{ app_name }}
+    operator.juju.is/target: application
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http-public
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ app_name }}


### PR DESCRIPTION
# Things added
- setup kratos pebble container
- push configs and identity schema to container
- observe on install and pebble ready event

# To test
`juju deploy ./kratos_ubuntu-*-amd64.charm --trust --resource oci-image=oryd/kratos:v0.10.1`
The charm should be able to arrive at Active Status

Note: you would not be able to use the kratos api yet because the database connection is not setup properly. Will work on relation with postgres and migration in future PR