### PR TITLE
Add dev flag

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,6 +11,6 @@ options:
     default: ""
   dev:
     description:
-      Run Kratos on dev mode, it is needed if HTTPS is not set up. This should only be used for developement purposes.
+      Run Kratos on dev mode, it is needed if HTTPS is not set up. This should only be used for development purposes.
     type: boolean
     default: False

--- a/config.yaml
+++ b/config.yaml
@@ -9,3 +9,8 @@ options:
       if Kratos is served via a reverse proxy).
     type: string
     default: ""
+  dev:
+    description:
+      Run Kratos on dev mode, it is needed if HTTPS is not set up. This should only be used for developement purposes.
+    type: boolean
+    default: False

--- a/src/charm.py
+++ b/src/charm.py
@@ -91,6 +91,15 @@ class KratosCharm(CharmBase):
         )
 
     @property
+    def _kratos_service_params(self):
+        ret = ["--config", str(self._config_file_path)]
+        if self.config["dev"]:
+            logger.warn("Running Kratos in dev mode, don't do this in production")
+            ret.append("--dev")
+
+        return " ".join(ret)
+
+    @property
     def _pebble_layer(self) -> Layer:
         pebble_layer = {
             "summary": "kratos layer",
@@ -100,7 +109,7 @@ class KratosCharm(CharmBase):
                     "override": "replace",
                     "summary": "Kratos Operator layer",
                     "startup": "disabled",
-                    "command": f"kratos serve all --config {self._config_file_path}",
+                    "command": f"kratos serve all " + self._kratos_service_params,
                 }
             },
             "checks": {

--- a/src/charm.py
+++ b/src/charm.py
@@ -109,7 +109,7 @@ class KratosCharm(CharmBase):
                     "override": "replace",
                     "summary": "Kratos Operator layer",
                     "startup": "disabled",
-                    "command": f"kratos serve all " + self._kratos_service_params,
+                    "command": "kratos serve all " + self._kratos_service_params,
                 }
             },
             "checks": {


### PR DESCRIPTION
Adds configuration option for using the `dev` flag when starting Kratos. This flag is needed when running Kratos without HTTPS