### PR TITLE
Add actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,56 @@ Relate the two charms to provide `identity-platform-login-ui-operator` with krat
 juju integrate kratos identity-platform-login-ui-operator
 ```
 
+## Actions
+
+The kratos charm offers the following actions:
+
+### create-admin-account
+
+This action can be used to create an admin account:
+
+```console
+juju run kratos/0 create-admin-account username=admin123 password=abc123456 email=admin@example.com
+```
+
+NOTE: The email registered for an admin account must not be used from any other user (admin or not).
+
+### get-identity
+
+This action can be used to get information about an existing identity:
+
+An identity_id can be used to specify the identity:
+```console
+juju run kratos/0 get-identity identity-id={identity_id}
+```
+
+An email can be used to specify the identity as well:
+```console
+juju run kratos/0 get-identity email={email}
+```
+
+### delete-identity
+
+This action can be used to delete an existing identity:
+
+An identity_id can be used to specify the identity:
+```console
+juju run kratos/0 delete-identity identity-id={identity_id}
+```
+
+An email can be used to specify the identity as well:
+```console
+juju run kratos/0 delete-identity email={email}
+```
+
+### run-migration
+
+This action can be used to trigger a database migration:
+
+```console
+juju run kratos/0 run-migration
+```
+
 ## OCI Images
 
 The image used by this charm is hosted on [Docker Hub](https://hub.docker.com/r/oryd/kratos) and maintained by Ory.

--- a/README.md
+++ b/README.md
@@ -123,14 +123,14 @@ NOTE: The email registered for an admin account must not be used for any other u
 
 ### get-identity
 
-This action can be used to get information about an existing identity:
+This action can be used to get information about an existing identity by email or id:
 
-An identity_id can be used to specify the identity:
+By id:
 ```console
 juju run kratos/0 get-identity identity-id={identity_id}
 ```
 
-An email can be used to specify the identity as well:
+By email:
 ```console
 juju run kratos/0 get-identity email={email}
 ```

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ This action can be used to create an admin account:
 juju run kratos/0 create-admin-account username=admin123 password=abc123456 email=admin@example.com
 ```
 
-NOTE: The email registered for an admin account must not be used from any other user (admin or not).
+NOTE: The email registered for an admin account must not be used for any other user (admin or not).
 
 ### get-identity
 

--- a/actions.yaml
+++ b/actions.yaml
@@ -54,7 +54,7 @@ create-admin-account:
       description: The admin's phone number
       type: string
   # TODO: Remove required password once password resetting is implemented
-  required: [username, password]
+  required: ["username", "password"]
 run-migration:
   description: |
     Run a migration, this is needed after upgrades. This is a non-reversible operation.

--- a/actions.yaml
+++ b/actions.yaml
@@ -16,21 +16,6 @@ delete-identity:
     email:
       description: The user's email
       type: string
-# reset-password:
-#   description: |
-#     Reset a user’s using either the identity ID or the user email, either a magic
-#     link or link and a one time code will be returned where the user will be asked to
-#     provide a new password
-#   params:
-#     identity-id:
-#       description: The Identity ID
-#       type: string
-#     email:
-#       description: The user's email
-#       type: string
-#     recovery-method:
-#       description: Whether a magic link or a one-time code will be used for resetting
-#       default: "link"
 create-admin-account:
   description: |
     Create an admin user. If no password was provided, the command will return a

--- a/actions.yaml
+++ b/actions.yaml
@@ -16,21 +16,21 @@ delete-identity:
     email:
       description: The user's email
       type: string
-reset-password:
-  description: |
-    Reset a user’s using either the identity ID or the user email, either a magic
-    link or link and a one time code will be returned where the user will be asked to
-    provide a new password
-  params:
-    identity-id:
-      description: The Identity ID
-      type: string
-    email:
-      description: The user's email
-      type: string
-    recovery-method:
-      description: Whether a magic link or a one-time code will be used for resetting
-      default: "link"
+# reset-password:
+#   description: |
+#     Reset a user’s using either the identity ID or the user email, either a magic
+#     link or link and a one time code will be returned where the user will be asked to
+#     provide a new password
+#   params:
+#     identity-id:
+#       description: The Identity ID
+#       type: string
+#     email:
+#       description: The user's email
+#       type: string
+#     recovery-method:
+#       description: Whether a magic link or a one-time code will be used for resetting
+#       default: "link"
 create-admin-account:
   description: |
     Create an admin user. If no password was provided, the command will return a
@@ -53,7 +53,8 @@ create-admin-account:
     phone_number:
       description: The admin's phone number
       type: string
-  required: [username]
+  # TODO: Remove required password once password resetting is implemented
+  required: [username, password]
 run-migration:
   description: |
     Run a migration, this is needed after upgrades. This is a non-reversible operation.

--- a/actions.yaml
+++ b/actions.yaml
@@ -62,5 +62,5 @@ run-migration:
   params:
     timeout:
       description: Timeout after which the migration will be canceled
-      type: integer
+      type: number
       default: 120

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,65 @@
+get-identity:
+  description: Get a user using either the identity ID or the user email.
+  params:
+    identity-id:
+      description: The Identity ID
+      type: string
+    email:
+      description: The user's email
+      type: string
+delete-identity:
+  description: Delete a user using either the identity ID or the user email.
+  params:
+    identity-id:
+      description: The Identity ID
+      type: string
+    email:
+      description: The user's email
+      type: string
+reset-password:
+  description: |
+    Reset a user’s using either the identity ID or the user email, either a magic
+    link or link and a one time code will be returned where the user will be asked to
+    provide a new password
+  params:
+    identity-id:
+      description: The Identity ID
+      type: string
+    email:
+      description: The user's email
+      type: string
+    recovery-method:
+      description: Whether a magic link or a one-time code will be used for resetting
+      default: "link"
+create-admin-account:
+  description: |
+    Create an admin user. If no password was provided, the command will return a
+    magic link where the user will be able to set their password.
+  params:
+    username:
+      description: The admin username
+      type: string
+    email:
+      description: |
+        The admin's email, this email must not be associated with any other account
+        (user or admin)
+      type: string
+    password:
+      description: The admin's password
+      type: string
+    name:
+      description: The admin's name
+      type: string
+    phone_number:
+      description: The admin's phone number
+      type: string
+  required: [username]
+run-migration:
+  description: |
+    Run a migration, this is needed after upgrades. This is a non-reversible operation.
+    Run this after backing up the database.
+  params:
+    timeout:
+      description: Timeout after which the migration will be canceled
+      type: integer
+      default: 120

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ lightkube
 lightkube-models
 Jinja2
 jsonschema
+requests

--- a/src/charm.py
+++ b/src/charm.py
@@ -69,7 +69,9 @@ class KratosCharm(CharmBase):
         self._config_dir_path = Path("/etc/config")
         self._config_file_path = self._config_dir_path / "kratos.yaml"
         self._identity_schema_file_path = self._config_dir_path / "identity.default.schema.json"
-        self._admin_identity_schema_file_path = self._config_dir_path / "identity.admin.schema.json"
+        self._admin_identity_schema_file_path = (
+            self._config_dir_path / "identity.admin.schema.json"
+        )
         self._mappers_dir_path = self._config_dir_path / "claim_mappers"
         self._mappers_local_dir_path = Path("claim_mappers")
         self._db_name = f"{self.model.name}_{self.app.name}"

--- a/src/charm.py
+++ b/src/charm.py
@@ -132,7 +132,8 @@ class KratosCharm(CharmBase):
 
         self.framework.observe(self.on.get_identity_action, self._on_get_identity_action)
         self.framework.observe(self.on.delete_identity_action, self._on_delete_identity_action)
-        self.framework.observe(self.on.reset_password_action, self._on_reset_password_action)
+        # TODO: Uncomment this line after we have implemented the recovery endpoint
+        # self.framework.observe(self.on.reset_password_action, self._on_reset_password_action)
         self.framework.observe(
             self.on.create_admin_account_action, self._on_create_admin_account_action
         )

--- a/src/charm.py
+++ b/src/charm.py
@@ -12,6 +12,7 @@ from os.path import join
 from pathlib import Path
 from typing import Optional
 
+import requests
 from charms.data_platform_libs.v0.data_interfaces import (
     DatabaseEndpointsChangedEvent,
     DatabaseRequires,
@@ -32,10 +33,12 @@ from charms.traefik_k8s.v1.ingress import (
     IngressPerAppRevokedEvent,
 )
 from jinja2 import Template
-from ops.charm import CharmBase, HookEvent, RelationEvent
+from ops.charm import ActionEvent, CharmBase, HookEvent, RelationEvent
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, ModelError, WaitingStatus
-from ops.pebble import ExecError, Layer
+from ops.pebble import Error, ExecError, Layer
+
+from kratos import KratosAPI
 
 logger = logging.getLogger(__name__)
 KRATOS_ADMIN_PORT = 4434
@@ -43,6 +46,17 @@ KRATOS_PUBLIC_PORT = 4433
 PEER_RELATION_NAME = "kratos-peers"
 PEER_KEY_DB_MIGRATE_VERSION = "db_migrate_version"
 DB_MIGRATE_VERSION = "0.11.1"
+
+
+def dict_to_action_output(d):
+    """Convert all keys in a dict to the format of a juju action output."""
+    ret = {}
+    for k, v in d.items():
+        k = k.replace("_", "-")
+        if isinstance(v, dict):
+            v = dict_to_action_output(v)
+        ret[k] = v
+    return ret
 
 
 class KratosCharm(CharmBase):
@@ -55,12 +69,16 @@ class KratosCharm(CharmBase):
         self._config_dir_path = Path("/etc/config")
         self._config_file_path = self._config_dir_path / "kratos.yaml"
         self._identity_schema_file_path = self._config_dir_path / "identity.default.schema.json"
+        self._admin_identity_schema_file_path = self._config_dir_path / "identity.admin.schema.json"
         self._mappers_dir_path = self._config_dir_path / "claim_mappers"
         self._mappers_local_dir_path = Path("claim_mappers")
         self._db_name = f"{self.model.name}_{self.app.name}"
         self._db_relation_name = "pg-database"
         self._hydra_relation_name = "endpoint-info"
 
+        self.kratos = KratosAPI(
+            f"http://127.0.0.1:{KRATOS_ADMIN_PORT}", self._container, str(self._config_file_path)
+        )
         self.service_patcher = KubernetesServicePatch(
             self, [("admin", KRATOS_ADMIN_PORT), ("public", KRATOS_PUBLIC_PORT)]
         )
@@ -110,6 +128,14 @@ class KratosCharm(CharmBase):
             self.external_provider.on.client_config_changed, self._on_client_config_changed
         )
 
+        self.framework.observe(self.on.get_identity_action, self._on_get_identity_action)
+        self.framework.observe(self.on.delete_identity_action, self._on_delete_identity_action)
+        self.framework.observe(self.on.reset_password_action, self._on_reset_password_action)
+        self.framework.observe(
+            self.on.create_admin_account_action, self._on_create_admin_account_action
+        )
+        self.framework.observe(self.on.run_migration_action, self._on_run_migration_action)
+
     @property
     def _kratos_service_params(self):
         ret = ["--config", str(self._config_file_path)]
@@ -118,6 +144,17 @@ class KratosCharm(CharmBase):
             ret.append("--dev")
 
         return " ".join(ret)
+
+    @property
+    def _kratos_service_is_running(self) -> bool:
+        if not self._container.can_connect():
+            return False
+
+        try:
+            service = self._container.get_service(self._container_name)
+        except (ModelError, RuntimeError):
+            return False
+        return service.is_running()
 
     @property
     def _pebble_layer(self) -> Layer:
@@ -165,6 +202,7 @@ class KratosCharm(CharmBase):
         rendered = template.render(
             mappers_path=str(self._mappers_dir_path),
             identity_schema_file_path=self._identity_schema_file_path,
+            admin_identity_schema_file_path=self._admin_identity_schema_file_path,
             default_browser_return_url=self.config.get("login_ui_url"),
             public_base_url=self._domain_url,
             login_ui_url=join(self.config.get("login_ui_url"), "login"),
@@ -277,6 +315,11 @@ class KratosCharm(CharmBase):
         with open("src/identity.default.schema.json", encoding="utf-8") as schema_file:
             schema = schema_file.read()
             self._container.push(self._identity_schema_file_path, schema, make_dirs=True)
+
+        with open("src/identity.admin.schema.json", encoding="utf-8") as schema_file:
+            schema = schema_file.read()
+            self._container.push(self._admin_identity_schema_file_path, schema, make_dirs=True)
+
         self._push_schemas()
 
         self._container.add_layer(self._container_name, self._pebble_layer, combine=True)
@@ -423,6 +466,154 @@ class KratosCharm(CharmBase):
         else:
             event.defer()
             logger.info("Database is not created. Deferring event.")
+
+    def _on_get_identity_action(self, event: ActionEvent) -> None:
+        if not self._kratos_service_is_running:
+            event.fail("Service is not ready. Please re-run the action when the charm is active")
+            return
+
+        event.log("Getting the identity.")
+        identity_id = event.params.get("identity-id")
+        email = event.params.get("email")
+        if identity_id and email:
+            event.fail("Only one of identity-id and email can be provided.")
+            return
+
+        event.log("Fetching the identity.")
+        if email:
+            try:
+                identity = self.kratos.get_identity_from_email(email)
+            except Error as e:
+                event.fail(f"Something went wrong when trying to run the command: {e}")
+                return
+            if not identity:
+                event.fail("Couldn't retrieve identity_id from email.")
+                return
+        else:
+            try:
+                identity = self.kratos.get_identity(identity_id=identity_id)
+            except Error as e:
+                event.fail(f"Something went wrong when trying to run the command: {e}")
+                return
+
+        event.log("Successfully got the identity.")
+        event.set_results(dict_to_action_output(identity))
+
+    def _on_delete_identity_action(self, event: ActionEvent) -> None:
+        if not self._kratos_service_is_running:
+            event.fail("Service is not ready. Please re-run the action when the charm is active")
+            return
+
+        identity_id = event.params.get("identity-id")
+        email = event.params.get("email")
+        if identity_id and email:
+            event.fail("Only one of identity-id and email can be provided.")
+            return
+
+        if email:
+            identity = self.kratos.get_identity_from_email(email)
+            if not identity:
+                event.fail("Couldn't retrieve identity_id from email.")
+                return
+
+        event.log("Deleting the identity.")
+        try:
+            self.kratos.delete_identity(identity_id=identity_id)
+        except Error as e:
+            event.fail(f"Something went wrong when trying to run the command: {e}")
+            return
+
+        event.log(f"Successfully deleted the identity: {identity_id}.")
+        event.set_results({"idenity-id": identity_id})
+
+    def _on_reset_password_action(self, event: ActionEvent) -> None:
+        if not self._kratos_service_is_running:
+            event.fail("Service is not ready. Please re-run the action when the charm is active")
+            return
+
+        identity_id = event.params.get("identity-id")
+        email = event.params.get("email")
+        recovery_method = event.params.get("recovery-method")
+        if identity_id and email:
+            event.fail("Only one of identity-id and email can be provided.")
+            return
+
+        if email:
+            identity = self.kratos.get_identity_from_email(email)
+            if not identity:
+                event.fail("Couldn't retrieve identity_id from email.")
+                return
+
+        if recovery_method == "code":
+            fun = self.kratos.recover_password_with_code
+        elif recovery_method == "link":
+            fun = self.kratos.recover_password_with_link
+        else:
+            event.fail(
+                f"Unsupported recovery method {recovery_method}, "
+                "allowed methods are: `code` and `link`"
+            )
+            return
+
+        event.log("Resetting password.")
+        try:
+            ret = fun(identity_id=identity_id)
+        except requests.exceptions.RequestException as e:
+            event.fail(f"Failed to request Kratos API: {e}")
+            return
+
+        event.log("Follow the link to reset the user's password")
+        event.set_results(dict_to_action_output(ret))
+
+    def _on_create_admin_account_action(self, event: ActionEvent) -> None:
+        if not self._kratos_service_is_running:
+            event.fail("Service is not ready. Please re-run the action when the charm is active")
+            return
+
+        traits = {
+            "username": event.params["username"],
+            "name": event.params.get("name"),
+            "email": event.params.get("email"),
+            "phone_number": event.params.get("phone_number"),
+        }
+        traits = {k: v for k, v in traits.items() if v is not None}
+        password = event.params.get("password")
+
+        event.log("Creating admin account.")
+        try:
+            identity = self.kratos.create_identity(traits, "admin", password=password)
+        except Error as e:
+            event.fail(f"Something went wrong when trying to run the command: {e}")
+            return
+
+        identity_id = identity["id"]
+        res = {"identity-id": identity_id}
+        event.log(f"Successfully created admin account: {identity_id}.")
+        if not password:
+            event.log("Creating magic link for resetting admin password.")
+            link = self.kratos.recover_password_with_link(identity_id)
+            res["password-reset-link"] = link["recovery_link"]
+            res["expires-at"] = link["expires_at"]
+
+        event.set_results(res)
+
+    def _on_run_migration_action(self, event: ActionEvent) -> None:
+        if not self._kratos_service_is_running:
+            event.fail("Service is not ready. Please re-run the action when the charm is active")
+            return
+
+        timeout = event.params.get("timeout")
+        event.log("Migrating database.")
+        try:
+            _, err = self.kratos.run_migration(timeout=timeout)
+        except Error as e:
+            event.fail(f"Something went wrong when trying to run the command: {e}")
+            return
+
+        if err:
+            event.fail(f"Something went wrong when running the migration: {err}")
+            return
+        event.log("Successfully migrated the database.")
 
 
 if __name__ == "__main__":

--- a/src/identity.admin.schema.json
+++ b/src/identity.admin.schema.json
@@ -1,0 +1,46 @@
+{
+  "$id": "https://schemas.ory.sh/presets/kratos/quickstart/email-password/identity.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Person",
+  "type": "object",
+  "properties": {
+    "traits": {
+      "type": "object",
+      "properties": {
+        "username": {
+          "type": "string",
+          "ory.sh/kratos": {
+            "credentials": {
+              "password": {
+                "identifier": true
+              }
+            }
+          }
+        },
+        "email": {
+          "type": "string",
+          "format": "email",
+          "title": "E-Mail",
+          "minLength": 3,
+          "ory.sh/kratos": {
+            "verification": {
+              "via": "email"
+            },
+            "recovery": {
+              "via": "email"
+            }
+          }
+        },
+        "name": {
+          "type": "string",
+          "title": "Name"
+        },
+        "phone_number": {
+          "type": "string",
+          "title": "Phone number"
+        }
+      }
+    },
+    "additionalProperties": true
+  }
+}

--- a/src/kratos.py
+++ b/src/kratos.py
@@ -143,7 +143,7 @@ class KratosAPI:
         return self._run_cmd(cmd, timeout=timeout)
 
     def _run_cmd(
-        self, cmd: List[str], timeout: float = 120, stdin: str = None
+        self, cmd: List[str], timeout: float = 20, stdin: str = None
     ) -> Tuple[Union[str, bytes], Union[str, bytes]]:
         logger.debug(f"Running cmd: {cmd}")
         process = self.container.exec(cmd, timeout=timeout)

--- a/src/kratos.py
+++ b/src/kratos.py
@@ -42,7 +42,7 @@ class KratosAPI:
 
         stdout, _ = self._run_cmd(cmd, stdin=json.dumps(identity))
         json_stdout = json.loads(stdout)
-        logger.info(f"Successfully created identitiy: {json_stdout.get('id')}")
+        logger.info(f"Successfully created identity: {json_stdout.get('id')}")
         return json_stdout
 
     def get_identity(self, identity_id: str) -> Dict:

--- a/src/kratos.py
+++ b/src/kratos.py
@@ -80,7 +80,7 @@ class KratosAPI:
         logger.info(f"Successfully deleted identity: {identity_id}")
         return stdout
 
-    def list_identities(self):
+    def list_identities(self) -> List:
         """List all identities."""
         cmd = [
             "kratos",
@@ -129,7 +129,7 @@ class KratosAPI:
 
         return r.json()
 
-    def run_migration(self, timeout: float = 120) -> Tuple[Union[str, bytes], Union[str, bytes]]:
+    def run_migration(self, timeout: float = 120) -> Tuple[str, str]:
         """Run an sql migration."""
         cmd = [
             "kratos",
@@ -143,12 +143,18 @@ class KratosAPI:
         return self._run_cmd(cmd, timeout=timeout)
 
     def _run_cmd(
-        self, cmd: List[str], timeout: float = 20, stdin: str = None
-    ) -> Tuple[Union[str, bytes], Union[str, bytes]]:
+        self, cmd: List[str], timeout: float = 20, stdin: Optional[str] = None
+    ) -> Tuple[str, str]:
         logger.debug(f"Running cmd: {cmd}")
         process = self.container.exec(cmd, timeout=timeout)
         if stdin:
             process.stdin.write(stdin)
             process.stdin.close()
         stdout, stderr = process.wait_output()
+
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode()
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode()
+
         return stdout, stderr

--- a/src/kratos.py
+++ b/src/kratos.py
@@ -1,0 +1,154 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""A helper class for interacting with the kratos API."""
+
+import json
+import logging
+from os.path import join
+from typing import Dict, List, Optional, Tuple, Union
+
+import requests
+from ops.model import Container
+
+logger = logging.getLogger(__name__)
+
+
+class KratosAPI:
+    """A helper object for interacting with the kratos API."""
+
+    def __init__(self, kratos_admin_url: str, container: Container, config_file_path: str) -> None:
+        self.kratos_admin_url = kratos_admin_url
+        self.container = container
+        self.config_file_path = config_file_path
+
+    def create_identity(
+        self, traits: Dict, schema_id: str, password: Optional[str] = None
+    ) -> Dict:
+        """Create an identity."""
+        cmd = [
+            "kratos",
+            "import",
+            "identities",
+            "--endpoint",
+            self.kratos_admin_url,
+            "--format",
+            "json",
+        ]
+
+        identity = {"traits": traits, "schema_id": schema_id}
+        if password:
+            identity["credentials"] = {"password": {"config": {"password": password}}}
+
+        stdout, _ = self._run_cmd(cmd, stdin=json.dumps(identity))
+        json_stdout = json.loads(stdout)
+        logger.info(f"Successfully created identitiy: {json_stdout.get('id')}")
+        return json_stdout
+
+    def get_identity(self, identity_id: str) -> Dict:
+        """Get an identity."""
+        cmd = [
+            "kratos",
+            "get",
+            "identity",
+            "--endpoint",
+            self.kratos_admin_url,
+            "--format",
+            "json",
+            identity_id,
+        ]
+
+        stdout, _ = self._run_cmd(cmd)
+        json_stdout = json.loads(stdout)
+        logger.info(f"Successfully fetched identity: {identity_id}")
+        return json_stdout
+
+    def delete_identity(self, identity_id: str) -> str:
+        """Get an identity."""
+        cmd = [
+            "kratos",
+            "delete",
+            "identity",
+            "--endpoint",
+            self.kratos_admin_url,
+            "--format",
+            "json",
+            identity_id,
+        ]
+
+        stdout, _ = self._run_cmd(cmd)
+        logger.info(f"Successfully deleted identity: {identity_id}")
+        return stdout
+
+    def list_identities(self):
+        """List all identities."""
+        cmd = [
+            "kratos",
+            "list",
+            "identities",
+            "--endpoint",
+            self.kratos_admin_url,
+            "--format",
+            "json",
+        ]
+
+        # TODO: Consider reading from the stream instead of waiting for output
+        stdout, _ = self._run_cmd(cmd)
+        json_stdout = json.loads(stdout)
+        logger.info("Successfully fetched all identities")
+        return json_stdout
+
+    def get_identity_from_email(self, email: str) -> Optional[Dict]:
+        """Get an identity using an email.
+
+        This will fetch all identities and iterate over them in memory.
+        """
+        ids = self.list_identities()
+        id = list(filter(lambda identity: identity["traits"].get("email") == email, ids))
+        if not id:
+            return None
+        return id[0]
+
+    def recover_password_with_code(self, identity_id: str, expires_in: str = "1h") -> Dict:
+        """Create a one time code for recovering an identity's password."""
+        url = join(self.kratos_admin_url, "admin/recovery/code")
+        data = dict(identity_id=identity_id, expires_in=expires_in)
+
+        r = requests.post(url, json=data)
+        r.raise_for_status()
+
+        return r.json()
+
+    def recover_password_with_link(self, identity_id: str, expires_in: str = "1h") -> Dict:
+        """Create a magic link for recovering an identity's password."""
+        url = join(self.kratos_admin_url, "admin/recovery/link")
+        data = dict(identity_id=identity_id, expires_in=expires_in)
+
+        r = requests.post(url, json=data)
+        r.raise_for_status()
+
+        return r.json()
+
+    def run_migration(self, timeout: float = 120) -> Tuple[Union[str, bytes], Union[str, bytes]]:
+        """Run an sql migration."""
+        cmd = [
+            "kratos",
+            "migrate",
+            "sql",
+            "-e",
+            "--config",
+            self.config_file_path,
+            "--yes",
+        ]
+        return self._run_cmd(cmd, timeout=timeout)
+
+    def _run_cmd(
+        self, cmd: List[str], timeout: float = 120, stdin: str = None
+    ) -> Tuple[Union[str, bytes], Union[str, bytes]]:
+        logger.debug(f"Running cmd: {cmd}")
+        process = self.container.exec(cmd, timeout=timeout)
+        if stdin:
+            process.stdin.write(stdin)
+            process.stdin.close()
+        stdout, stderr = process.wait_output()
+        return stdout, stderr

--- a/src/kratos.py
+++ b/src/kratos.py
@@ -6,7 +6,7 @@
 import json
 import logging
 from os.path import join
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple
 
 import requests
 from ops.model import Container

--- a/templates/kratos.yaml.j2
+++ b/templates/kratos.yaml.j2
@@ -5,6 +5,8 @@ identity:
     schemas:
         - id: default
           url: 'file://{{ identity_schema_file_path }}'
+        - id: admin
+          url: 'file://{{ admin_identity_schema_file_path }}'
 selfservice:
     default_browser_return_url:
         {{ default_browser_return_url }}

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -113,8 +113,8 @@ async def test_create_admin_account(ops_test: OpsTest):
                 "email": ADMIN_MAIL,
                 "name": "Admin Admin",
                 "phone_number": "6912345678",
-                "password": "123456"
-            }
+                "password": "123456",
+            },
         )
     )
 
@@ -139,10 +139,7 @@ async def test_get_identity(ops_test: OpsTest):
 
 
 @pytest.mark.skip(
-    reason=(
-        "the recovery and settings UI page must be provided to kratos for this "
-        "to work"
-    )
+    reason=("the recovery and settings UI page must be provided to kratos for this " "to work")
 )
 async def test_reset_password(ops_test: OpsTest):
     action = (
@@ -178,7 +175,7 @@ async def test_delete_identity(ops_test: OpsTest):
             "delete-identity",
             **{
                 "identity-id": res["id"],
-            }
+            },
         )
     )
 
@@ -192,6 +189,6 @@ async def test_delete_identity(ops_test: OpsTest):
             email=ADMIN_MAIL,
         )
     )
-    res = (await action.wait())
+    res = await action.wait()
 
     assert res.message == "Couldn't retrieve identity_id from email."

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -102,7 +102,7 @@ async def test_has_admin_ingress(ops_test: OpsTest):
 
 
 @pytest.mark.abort_on_fail
-async def test_create_admin_account(ops_test: OpsTest):
+async def test_create_admin_account(ops_test: OpsTest) -> None:
     action = (
         await ops_test.model.applications[APP_NAME]
         .units[0]
@@ -123,7 +123,7 @@ async def test_create_admin_account(ops_test: OpsTest):
     assert "identity-id" in res.results
 
 
-async def test_get_identity(ops_test: OpsTest):
+async def test_get_identity(ops_test: OpsTest) -> None:
     action = (
         await ops_test.model.applications[APP_NAME]
         .units[0]
@@ -141,7 +141,7 @@ async def test_get_identity(ops_test: OpsTest):
 @pytest.mark.skip(
     reason=("the recovery and settings UI page must be provided to kratos for this test to work")
 )
-async def test_reset_password(ops_test: OpsTest):
+async def test_reset_password(ops_test: OpsTest) -> None:
     action = (
         await ops_test.model.applications[APP_NAME]
         .units[0]
@@ -156,7 +156,7 @@ async def test_reset_password(ops_test: OpsTest):
     assert "recovery_link" in res
 
 
-async def test_delete_identity(ops_test: OpsTest):
+async def test_delete_identity(ops_test: OpsTest) -> None:
     action = (
         await ops_test.model.applications[APP_NAME]
         .units[0]

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -18,6 +18,7 @@ POSTGRES = "postgresql-k8s"
 TRAEFIK = "traefik-k8s"
 TRAEFIK_ADMIN_APP = "traefik-admin"
 TRAEFIK_PUBLIC_APP = "traefik-public"
+ADMIN_MAIL = "admin@adminmail.com"
 
 
 async def get_unit_address(ops_test: OpsTest, app_name: str, unit_num: int) -> str:
@@ -98,3 +99,99 @@ async def test_has_admin_ingress(ops_test: OpsTest):
     )
 
     assert resp.status_code == 200
+
+
+@pytest.mark.abort_on_fail
+async def test_create_admin_account(ops_test: OpsTest):
+    action = (
+        await ops_test.model.applications[APP_NAME]
+        .units[0]
+        .run_action(
+            "create-admin-account",
+            **{
+                "username": "admin",
+                "email": ADMIN_MAIL,
+                "name": "Admin Admin",
+                "phone_number": "6912345678",
+                "password": "123456"
+            }
+        )
+    )
+
+    res = await action.wait()
+
+    assert "identity-id" in res.results
+
+
+async def test_get_identity(ops_test: OpsTest):
+    action = (
+        await ops_test.model.applications[APP_NAME]
+        .units[0]
+        .run_action(
+            "get-identity",
+            email=ADMIN_MAIL,
+        )
+    )
+
+    res = (await action.wait()).results
+
+    assert res["id"]
+
+
+@pytest.mark.skip(
+    reason=(
+        "the recovery and settings UI page must be provided to kratos for this "
+        "to work"
+    )
+)
+async def test_reset_password(ops_test: OpsTest):
+    action = (
+        await ops_test.model.applications[APP_NAME]
+        .units[0]
+        .run_action(
+            "reset-password",
+            email=ADMIN_MAIL,
+        )
+    )
+
+    res = (await action.wait()).results
+
+    assert "recovery_link" in res
+
+
+async def test_delete_identity(ops_test: OpsTest):
+    action = (
+        await ops_test.model.applications[APP_NAME]
+        .units[0]
+        .run_action(
+            "get-identity",
+            email=ADMIN_MAIL,
+        )
+    )
+
+    res = (await action.wait()).results
+
+    action = (
+        await ops_test.model.applications[APP_NAME]
+        .units[0]
+        .run_action(
+            "delete-identity",
+            **{
+                "identity-id": res["id"],
+            }
+        )
+    )
+
+    res = (await action.wait()).results
+
+    action = (
+        await ops_test.model.applications[APP_NAME]
+        .units[0]
+        .run_action(
+            "get-identity",
+            email=ADMIN_MAIL,
+        )
+    )
+    res = (await action.wait())
+
+    assert res.message == "Couldn't retrieve identity_id from email."

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -139,7 +139,7 @@ async def test_get_identity(ops_test: OpsTest):
 
 
 @pytest.mark.skip(
-    reason=("the recovery and settings UI page must be provided to kratos for this " "to work")
+    reason=("the recovery and settings UI page must be provided to kratos for this test to work")
 )
 async def test_reset_password(ops_test: OpsTest):
     action = (

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,9 +1,13 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+from typing import Dict, Generator
+from unittest.mock import MagicMock
+
 import pytest
 from ops.pebble import ExecError
 from ops.testing import Harness
+from pytest_mock import MockerFixture
 
 from charm import KratosCharm
 
@@ -23,6 +27,11 @@ def mocked_kubernetes_service_patcher(mocker):
     mocked_service_patcher = mocker.patch("charm.KubernetesServicePatch")
     mocked_service_patcher.return_value = lambda x, y: None
     yield mocked_service_patcher
+
+
+@pytest.fixture()
+def mocked_kratos_is_running(mocker: MockerFixture) -> Generator:
+    return mocker.patch("charm.KratosCharm._kratos_service_is_running", return_value=True)
 
 
 @pytest.fixture()
@@ -59,3 +68,101 @@ def mocked_pebble_exec_failed(mocked_pebble_exec):
         exit_code=400, stderr="Failed to execute", stdout="Failed", command="test command"
     )
     yield
+
+
+@pytest.fixture()
+def kratos_identity_json() -> Dict:
+    return {
+        "created_at": "2023-03-31T14:04:49.667264Z",
+        "credentials": {
+            "password": {
+                "created_at": "2023-03-31T14:04:49.667718Z",
+                "identifiers": ["admin"],
+                "type": "password",
+                "updated_at": "2023-03-31T14:04:49.667718Z",
+                "version": 0,
+            }
+        },
+        "id": "5be8ea62-1c64-4a28-ac0c-7dd7d9cf7d05",
+        "schema_id": "admin",
+        "schema_url": "http://localhost:4433/schemas/YWRtaW4",
+        "state": "active",
+        "state_changed_at": "2023-03-31T14:04:49.666623636Z",
+        "traits": {
+            "email": "aa@bb.com",
+            "name": "Joe Doe",
+            "phone_number": "+306912345678",
+            "username": "admin",
+        },
+        "updated_at": "2023-03-31T14:04:49.667264Z",
+        "verifiable_addresses": [
+            {
+                "created_at": "2023-03-31T14:04:49.667503Z",
+                "id": "02321296-6069-483f-b17a-9889fdae722f",
+                "status": "pending",
+                "updated_at": "2023-03-31T14:04:49.667503Z",
+                "value": "aa@bb.com",
+                "verified": False,
+                "via": "email",
+            }
+        ],
+    }
+
+
+@pytest.fixture()
+def mocked_get_identity(mocker: MockerFixture, kratos_identity_json: Dict) -> MagicMock:
+    mock = mocker.patch("charm.KratosAPI.get_identity", return_value=kratos_identity_json)
+    return mock
+
+
+@pytest.fixture()
+def mocked_delete_identity(mocker: MockerFixture, kratos_identity_json: Dict) -> MagicMock:
+    mock = mocker.patch("charm.KratosAPI.delete_identity", return_value=kratos_identity_json["id"])
+    return mock
+
+
+@pytest.fixture()
+def mocked_list_identity(mocker: MockerFixture, kratos_identity_json: Dict) -> MagicMock:
+    mock = mocker.patch("charm.KratosAPI.list_identities", return_value=[kratos_identity_json])
+    return mock
+
+
+@pytest.fixture()
+def mocked_get_identity_from_email(mocker: MockerFixture, kratos_identity_json: Dict) -> MagicMock:
+    mock = mocker.patch(
+        "charm.KratosAPI.get_identity_from_email", return_value=kratos_identity_json
+    )
+    return mock
+
+
+@pytest.fixture()
+def mocked_recover_password_with_code(mocker: MockerFixture) -> MagicMock:
+    ret = {
+        "recovery_link": "http://kratos-ui/recovery?flow=2ebd739f-7c9c-404e-8ec9-769c055f5393",
+        "recovery_code": "123456",
+        "expires_at": "2023-04-03T21:47:52.869721347Z",
+    }
+    mock = mocker.patch("charm.KratosAPI.recover_password_with_code", return_value=ret)
+    return mock
+
+
+@pytest.fixture()
+def mocked_recover_password_with_link(mocker: MockerFixture) -> MagicMock:
+    ret = {
+        "recovery_link": "http://kratos-ui/self-service/recovery?flow=e18560f9-8f50-4679-bcc9-d6cea2bb203f&token=5UJ9GgQTxvSp53zkwgOkjG9eRvnYjEYq",
+        "expires_at": "2023-04-03T21:47:52.869721347Z",
+    }
+    mock = mocker.patch("charm.KratosAPI.recover_password_with_link", return_value=ret)
+    return mock
+
+
+@pytest.fixture()
+def mocked_create_identity(mocker: MockerFixture, kratos_identity_json: Dict) -> MagicMock:
+    mock = mocker.patch("charm.KratosAPI.create_identity", return_value=kratos_identity_json)
+    return mock
+
+
+@pytest.fixture()
+def mocked_run_migration(mocker: MockerFixture) -> MagicMock:
+    mock = mocker.patch("charm.KratosAPI.run_migration", return_value=(None, None))
+    return mock

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2,10 +2,14 @@
 # See LICENSE file for licensing details.
 
 import json
+from unittest.mock import MagicMock
 
 import pytest
+import requests
 import yaml
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
+from ops.pebble import ExecError, TimeoutError
+from ops.testing import Harness
 
 from charm import DB_MIGRATE_VERSION, PEER_KEY_DB_MIGRATE_VERSION
 
@@ -714,3 +718,318 @@ def test_kratos_endpoint_info_relation_data_with_ingress_relation_data(harness) 
     }
 
     assert harness.get_relation_data(endpoint_info_relation_id, "kratos") == expected_data
+
+
+@pytest.mark.parametrize(
+    "action",
+    [
+        "_on_get_identity_action",
+        "_on_delete_identity_action",
+        "_on_reset_password_action",
+        "_on_create_admin_account_action",
+        "_on_run_migration_action",
+    ],
+)
+def test_actions_when_cannot_connect(harness: Harness, action: str) -> None:
+    harness.set_can_connect(CONTAINER_NAME, False)
+    event = MagicMock()
+
+    getattr(harness.charm, action)(event)
+
+    event.fail.assert_called_with(
+        "Service is not ready. Please re-run the action when the charm is active"
+    )
+
+
+def test_get_identity_action_with_identity_id(
+    harness: Harness, mocked_kratos_is_running: MagicMock, mocked_get_identity: MagicMock
+) -> None:
+    identity_id = mocked_get_identity.return_value["id"]
+    event = MagicMock()
+    event.params = {"identity-id": identity_id}
+
+    harness.charm._on_get_identity_action(event)
+
+    event.set_results.assert_called()
+
+
+def test_error_on_get_identity_action_with_identity_id(
+    harness: Harness, mocked_kratos_is_running: MagicMock, mocked_get_identity: MagicMock
+) -> None:
+    mocked_get_identity.side_effect = ExecError(
+        command=["kratos", "get", "identity"], exit_code=1, stdout="", stderr="Error"
+    )
+    event = MagicMock()
+    event.params = {"identity-id": "identity_id"}
+
+    harness.charm._on_get_identity_action(event)
+
+    event.fail.assert_called()
+
+
+def test_get_identity_action_with_email(
+    harness: Harness,
+    mocked_kratos_is_running: MagicMock,
+    mocked_get_identity_from_email: MagicMock,
+) -> None:
+    email = mocked_get_identity_from_email.return_value["traits"]["email"]
+    event = MagicMock()
+    event.params = {"email": email}
+
+    harness.charm._on_get_identity_action(event)
+
+    event.set_results.assert_called()
+
+
+def test_get_identity_action_with_wrong_email(
+    harness: Harness,
+    mocked_kratos_is_running: MagicMock,
+    mocked_get_identity_from_email: MagicMock,
+) -> None:
+    mocked_get_identity_from_email.return_value = None
+    event = MagicMock()
+    event.params = {"email": "email"}
+
+    harness.charm._on_get_identity_action(event)
+
+    event.fail.assert_called_with("Couldn't retrieve identity_id from email.")
+    event.set_results.assert_not_called()
+
+
+def test_error_on_get_identity_action_with_email(
+    harness: Harness,
+    mocked_kratos_is_running: MagicMock,
+    mocked_get_identity_from_email: MagicMock,
+) -> None:
+    mocked_get_identity_from_email.side_effect = ExecError(
+        command=["kratos", "list", "identities"], exit_code=1, stdout="", stderr="Error"
+    )
+    event = MagicMock()
+    event.params = {"email": "email"}
+
+    harness.charm._on_get_identity_action(event)
+
+    event.fail.assert_called()
+
+
+def test_delete_identity_action_with_identity_id(
+    harness: Harness, mocked_kratos_is_running: MagicMock, mocked_delete_identity: MagicMock
+) -> None:
+    identity_id = mocked_delete_identity.return_value
+    event = MagicMock()
+    event.params = {"identity-id": identity_id}
+
+    harness.charm._on_delete_identity_action(event)
+
+    event.set_results.assert_called()
+
+
+def test_error_on_delete_identity_action_with_identity_id(
+    harness: Harness, mocked_kratos_is_running: MagicMock, mocked_delete_identity: MagicMock
+) -> None:
+    mocked_delete_identity.side_effect = ExecError(
+        command=["kratos", "delete", "identity"], exit_code=1, stdout="", stderr="Error"
+    )
+    event = MagicMock()
+    event.params = {"identity-id": "identity_id"}
+
+    harness.charm._on_delete_identity_action(event)
+
+    event.fail.assert_called()
+
+
+def test_delete_identity_action_with_email(
+    harness: Harness,
+    mocked_kratos_is_running: MagicMock,
+    mocked_get_identity_from_email: MagicMock,
+    mocked_delete_identity: MagicMock,
+) -> None:
+    email = mocked_get_identity_from_email.return_value["traits"]["email"]
+    event = MagicMock()
+    event.params = {"email": email}
+
+    harness.charm._on_delete_identity_action(event)
+
+    event.set_results.assert_called()
+
+
+def test_error_on_delete_identity_action_with_email(
+    harness: Harness,
+    mocked_kratos_is_running: MagicMock,
+    mocked_get_identity_from_email: MagicMock,
+    mocked_delete_identity: MagicMock,
+) -> None:
+    mocked_delete_identity.side_effect = ExecError(
+        command=["kratos", "delete", "identity"], exit_code=1, stdout="", stderr="Error"
+    )
+    event = MagicMock()
+    event.params = {"email": "email"}
+
+    harness.charm._on_delete_identity_action(event)
+
+    event.fail.assert_called()
+
+
+def test_reset_password_action_with_code_with_identity_id(
+    harness: Harness,
+    mocked_kratos_is_running: MagicMock,
+    mocked_recover_password_with_code: MagicMock,
+) -> None:
+    identity_id = mocked_recover_password_with_code.return_value
+    event = MagicMock()
+    event.params = {"identity-id": identity_id, "recovery-method": "code"}
+
+    harness.charm._on_reset_password_action(event)
+
+    event.set_results.assert_called()
+
+
+def test_error_on_reset_password_action_with_code_with_identity_id(
+    harness: Harness,
+    mocked_kratos_is_running: MagicMock,
+    mocked_recover_password_with_code: MagicMock,
+) -> None:
+    mocked_recover_password_with_code.side_effect = requests.exceptions.HTTPError()
+    event = MagicMock()
+    event.params = {"identity-id": "identity_id", "recovery-method": "code"}
+
+    harness.charm._on_reset_password_action(event)
+
+    event.fail.assert_called()
+
+
+def test_reset_password_action_with_code_with_email(
+    harness: Harness,
+    mocked_kratos_is_running: MagicMock,
+    mocked_get_identity_from_email: MagicMock,
+    mocked_recover_password_with_code: MagicMock,
+) -> None:
+    identity_id = mocked_recover_password_with_code.return_value
+    event = MagicMock()
+    event.params = {"identity-id": identity_id, "recovery-method": "code"}
+
+    harness.charm._on_reset_password_action(event)
+
+    event.set_results.assert_called()
+
+
+def test_reset_password_action_with_link_with_identity_id(
+    harness: Harness,
+    mocked_kratos_is_running: MagicMock,
+    mocked_recover_password_with_link: MagicMock,
+) -> None:
+    identity_id = mocked_recover_password_with_link.return_value
+    event = MagicMock()
+    event.params = {"identity-id": identity_id, "recovery-method": "link"}
+
+    harness.charm._on_reset_password_action(event)
+
+    event.set_results.assert_called()
+
+
+def test_error_on_reset_password_action_with_link_with_identity_id(
+    harness: Harness,
+    mocked_kratos_is_running: MagicMock,
+    mocked_recover_password_with_link: MagicMock,
+) -> None:
+    mocked_recover_password_with_link.side_effect = requests.exceptions.HTTPError()
+    event = MagicMock()
+    event.params = {"identity-id": "identity_id", "recovery-method": "link"}
+
+    harness.charm._on_reset_password_action(event)
+
+    event.fail.assert_called()
+
+
+def test_reset_password_action_with_link_with_email(
+    harness: Harness,
+    mocked_kratos_is_running: MagicMock,
+    mocked_get_identity_from_email: MagicMock,
+    mocked_recover_password_with_link: MagicMock,
+) -> None:
+    identity_id = mocked_recover_password_with_link.return_value
+    event = MagicMock()
+    event.params = {"identity-id": identity_id, "recovery-method": "link"}
+
+    harness.charm._on_reset_password_action(event)
+
+    event.set_results.assert_called()
+
+
+def test_error_on_reset_password_action_with_link_with_email(
+    harness: Harness,
+    mocked_kratos_is_running: MagicMock,
+    mocked_get_identity_from_email: MagicMock,
+    mocked_recover_password_with_link: MagicMock,
+) -> None:
+    mocked_recover_password_with_link.side_effect = requests.exceptions.HTTPError()
+    event = MagicMock()
+    event.params = {"identity-id": "identity_id", "recovery-method": "link"}
+
+    harness.charm._on_reset_password_action(event)
+
+    event.fail.assert_called()
+
+
+def test_create_admin_account_with_password(
+    harness: Harness, mocked_kratos_is_running: MagicMock, mocked_create_identity: MagicMock
+) -> None:
+    identity_id = mocked_create_identity.return_value["id"]
+    event = MagicMock()
+    event.params = {"username": "username", "password": "p4sSw0rC"}
+
+    harness.charm._on_create_admin_account_action(event)
+
+    event.set_results.assert_called_with({"identity-id": identity_id})
+
+
+def test_create_admin_account_without_password(
+    harness: Harness,
+    mocked_kratos_is_running: MagicMock,
+    mocked_create_identity: MagicMock,
+    mocked_recover_password_with_link: MagicMock,
+) -> None:
+    event = MagicMock()
+    event.params = {"username": "username"}
+
+    harness.charm._on_create_admin_account_action(event)
+
+    event.set_results.assert_called_with(
+        {
+            "identity-id": mocked_create_identity.return_value["id"],
+            "password-reset-link": mocked_recover_password_with_link.return_value["recovery_link"],
+            "expires-at": mocked_recover_password_with_link.return_value["expires_at"],
+        }
+    )
+
+
+def test_run_migration(
+    harness: Harness, mocked_kratos_is_running: MagicMock, mocked_run_migration: MagicMock
+) -> None:
+    event = MagicMock()
+
+    harness.charm._on_run_migration_action(event)
+
+    event.log.assert_called_with("Successfully migrated the database.")
+
+
+def test_error_on_run_migration(
+    harness: Harness, mocked_kratos_is_running: MagicMock, mocked_run_migration: MagicMock
+) -> None:
+    mocked_run_migration.return_value= (None, "Error")
+    event = MagicMock()
+
+    harness.charm._on_run_migration_action(event)
+
+    event.fail.assert_called()
+
+
+def test_timeout_on_run_migration(
+    harness: Harness, mocked_kratos_is_running: MagicMock, mocked_run_migration: MagicMock
+) -> None:
+    mocked_run_migration.side_effect = TimeoutError
+    event = MagicMock()
+
+    harness.charm._on_run_migration_action(event)
+
+    event.fail.assert_called()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -747,7 +747,7 @@ def test_actions_when_cannot_connect(harness: Harness, action: str) -> None:
 
 
 def test_get_identity_action_with_identity_id(
-    harness: Harness, mocked_kratos_is_running: MagicMock, mocked_get_identity: MagicMock
+    harness: Harness, mocked_kratos_service: MagicMock, mocked_get_identity: MagicMock
 ) -> None:
     identity_id = mocked_get_identity.return_value["id"]
     event = MagicMock()
@@ -759,7 +759,7 @@ def test_get_identity_action_with_identity_id(
 
 
 def test_error_on_get_identity_action_with_identity_id(
-    harness: Harness, mocked_kratos_is_running: MagicMock, mocked_get_identity: MagicMock
+    harness: Harness, mocked_kratos_service: MagicMock, mocked_get_identity: MagicMock
 ) -> None:
     mocked_get_identity.side_effect = ExecError(
         command=["kratos", "get", "identity"], exit_code=1, stdout="", stderr="Error"
@@ -774,7 +774,7 @@ def test_error_on_get_identity_action_with_identity_id(
 
 def test_get_identity_action_with_email(
     harness: Harness,
-    mocked_kratos_is_running: MagicMock,
+    mocked_kratos_service: MagicMock,
     mocked_get_identity_from_email: MagicMock,
 ) -> None:
     email = mocked_get_identity_from_email.return_value["traits"]["email"]
@@ -788,7 +788,7 @@ def test_get_identity_action_with_email(
 
 def test_get_identity_action_with_wrong_email(
     harness: Harness,
-    mocked_kratos_is_running: MagicMock,
+    mocked_kratos_service: MagicMock,
     mocked_get_identity_from_email: MagicMock,
 ) -> None:
     mocked_get_identity_from_email.return_value = None
@@ -803,7 +803,7 @@ def test_get_identity_action_with_wrong_email(
 
 def test_error_on_get_identity_action_with_email(
     harness: Harness,
-    mocked_kratos_is_running: MagicMock,
+    mocked_kratos_service: MagicMock,
     mocked_get_identity_from_email: MagicMock,
 ) -> None:
     mocked_get_identity_from_email.side_effect = ExecError(
@@ -818,7 +818,7 @@ def test_error_on_get_identity_action_with_email(
 
 
 def test_delete_identity_action_with_identity_id(
-    harness: Harness, mocked_kratos_is_running: MagicMock, mocked_delete_identity: MagicMock
+    harness: Harness, mocked_kratos_service: MagicMock, mocked_delete_identity: MagicMock
 ) -> None:
     identity_id = mocked_delete_identity.return_value
     event = MagicMock()
@@ -830,7 +830,7 @@ def test_delete_identity_action_with_identity_id(
 
 
 def test_error_on_delete_identity_action_with_identity_id(
-    harness: Harness, mocked_kratos_is_running: MagicMock, mocked_delete_identity: MagicMock
+    harness: Harness, mocked_kratos_service: MagicMock, mocked_delete_identity: MagicMock
 ) -> None:
     mocked_delete_identity.side_effect = ExecError(
         command=["kratos", "delete", "identity"], exit_code=1, stdout="", stderr="Error"
@@ -845,7 +845,7 @@ def test_error_on_delete_identity_action_with_identity_id(
 
 def test_delete_identity_action_with_email(
     harness: Harness,
-    mocked_kratos_is_running: MagicMock,
+    mocked_kratos_service: MagicMock,
     mocked_get_identity_from_email: MagicMock,
     mocked_delete_identity: MagicMock,
 ) -> None:
@@ -860,7 +860,7 @@ def test_delete_identity_action_with_email(
 
 def test_error_on_delete_identity_action_with_email(
     harness: Harness,
-    mocked_kratos_is_running: MagicMock,
+    mocked_kratos_service: MagicMock,
     mocked_get_identity_from_email: MagicMock,
     mocked_delete_identity: MagicMock,
 ) -> None:
@@ -877,7 +877,7 @@ def test_error_on_delete_identity_action_with_email(
 
 def test_reset_password_action_with_code_with_identity_id(
     harness: Harness,
-    mocked_kratos_is_running: MagicMock,
+    mocked_kratos_service: MagicMock,
     mocked_recover_password_with_code: MagicMock,
 ) -> None:
     identity_id = mocked_recover_password_with_code.return_value
@@ -891,7 +891,7 @@ def test_reset_password_action_with_code_with_identity_id(
 
 def test_error_on_reset_password_action_with_code_with_identity_id(
     harness: Harness,
-    mocked_kratos_is_running: MagicMock,
+    mocked_kratos_service: MagicMock,
     mocked_recover_password_with_code: MagicMock,
 ) -> None:
     mocked_recover_password_with_code.side_effect = requests.exceptions.HTTPError()
@@ -905,7 +905,7 @@ def test_error_on_reset_password_action_with_code_with_identity_id(
 
 def test_reset_password_action_with_code_with_email(
     harness: Harness,
-    mocked_kratos_is_running: MagicMock,
+    mocked_kratos_service: MagicMock,
     mocked_get_identity_from_email: MagicMock,
     mocked_recover_password_with_code: MagicMock,
 ) -> None:
@@ -920,7 +920,7 @@ def test_reset_password_action_with_code_with_email(
 
 def test_reset_password_action_with_link_with_identity_id(
     harness: Harness,
-    mocked_kratos_is_running: MagicMock,
+    mocked_kratos_service: MagicMock,
     mocked_recover_password_with_link: MagicMock,
 ) -> None:
     identity_id = mocked_recover_password_with_link.return_value
@@ -934,7 +934,7 @@ def test_reset_password_action_with_link_with_identity_id(
 
 def test_error_on_reset_password_action_with_link_with_identity_id(
     harness: Harness,
-    mocked_kratos_is_running: MagicMock,
+    mocked_kratos_service: MagicMock,
     mocked_recover_password_with_link: MagicMock,
 ) -> None:
     mocked_recover_password_with_link.side_effect = requests.exceptions.HTTPError()
@@ -948,7 +948,7 @@ def test_error_on_reset_password_action_with_link_with_identity_id(
 
 def test_reset_password_action_with_link_with_email(
     harness: Harness,
-    mocked_kratos_is_running: MagicMock,
+    mocked_kratos_service: MagicMock,
     mocked_get_identity_from_email: MagicMock,
     mocked_recover_password_with_link: MagicMock,
 ) -> None:
@@ -963,7 +963,7 @@ def test_reset_password_action_with_link_with_email(
 
 def test_error_on_reset_password_action_with_link_with_email(
     harness: Harness,
-    mocked_kratos_is_running: MagicMock,
+    mocked_kratos_service: MagicMock,
     mocked_get_identity_from_email: MagicMock,
     mocked_recover_password_with_link: MagicMock,
 ) -> None:
@@ -977,7 +977,7 @@ def test_error_on_reset_password_action_with_link_with_email(
 
 
 def test_create_admin_account_with_password(
-    harness: Harness, mocked_kratos_is_running: MagicMock, mocked_create_identity: MagicMock
+    harness: Harness, mocked_kratos_service: MagicMock, mocked_create_identity: MagicMock
 ) -> None:
     identity_id = mocked_create_identity.return_value["id"]
     event = MagicMock()
@@ -990,7 +990,7 @@ def test_create_admin_account_with_password(
 
 def test_create_admin_account_without_password(
     harness: Harness,
-    mocked_kratos_is_running: MagicMock,
+    mocked_kratos_service: MagicMock,
     mocked_create_identity: MagicMock,
     mocked_recover_password_with_link: MagicMock,
 ) -> None:
@@ -1009,7 +1009,7 @@ def test_create_admin_account_without_password(
 
 
 def test_run_migration(
-    harness: Harness, mocked_kratos_is_running: MagicMock, mocked_run_migration: MagicMock
+    harness: Harness, mocked_kratos_service: MagicMock, mocked_run_migration: MagicMock
 ) -> None:
     event = MagicMock()
 
@@ -1019,7 +1019,7 @@ def test_run_migration(
 
 
 def test_error_on_run_migration(
-    harness: Harness, mocked_kratos_is_running: MagicMock, mocked_run_migration: MagicMock
+    harness: Harness, mocked_kratos_service: MagicMock, mocked_run_migration: MagicMock
 ) -> None:
     mocked_run_migration.return_value = (None, "Error")
     event = MagicMock()
@@ -1030,7 +1030,7 @@ def test_error_on_run_migration(
 
 
 def test_timeout_on_run_migration(
-    harness: Harness, mocked_kratos_is_running: MagicMock, mocked_run_migration: MagicMock
+    harness: Harness, mocked_kratos_service: MagicMock, mocked_run_migration: MagicMock
 ) -> None:
     mocked_run_migration.side_effect = TimeoutError
     event = MagicMock()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -183,7 +183,8 @@ def test_on_pebble_ready_has_correct_config_when_database_is_created(harness) ->
         "identity": {
             "default_schema_id": "default",
             "schemas": [
-                {"id": "default", "url": "file:///etc/config/identity.default.schema.json"}
+                {"id": "default", "url": "file:///etc/config/identity.default.schema.json"},
+                {"id": "admin", "url": "file:///etc/config/identity.admin.schema.json"},
             ],
         },
         "selfservice": {
@@ -439,7 +440,8 @@ def test_on_client_config_changed_with_ingress(harness, mocked_container) -> Non
         "identity": {
             "default_schema_id": "default",
             "schemas": [
-                {"id": "default", "url": "file:///etc/config/identity.default.schema.json"}
+                {"id": "default", "url": "file:///etc/config/identity.default.schema.json"},
+                {"id": "admin", "url": "file:///etc/config/identity.admin.schema.json"},
             ],
         },
         "selfservice": {
@@ -513,7 +515,8 @@ def test_on_client_config_changed_with_external_url_config(harness, mocked_conta
         "identity": {
             "default_schema_id": "default",
             "schemas": [
-                {"id": "default", "url": "file:///etc/config/identity.default.schema.json"}
+                {"id": "default", "url": "file:///etc/config/identity.default.schema.json"},
+                {"id": "admin", "url": "file:///etc/config/identity.admin.schema.json"},
             ],
         },
         "selfservice": {
@@ -592,7 +595,8 @@ def test_on_client_config_changed_with_hydra(harness) -> None:
         "identity": {
             "default_schema_id": "default",
             "schemas": [
-                {"id": "default", "url": "file:///etc/config/identity.default.schema.json"}
+                {"id": "default", "url": "file:///etc/config/identity.default.schema.json"},
+                {"id": "admin", "url": "file:///etc/config/identity.admin.schema.json"},
             ],
         },
         "selfservice": {
@@ -646,7 +650,8 @@ def test_on_client_config_changed_when_missing_hydra_relation_data(harness) -> N
         "identity": {
             "default_schema_id": "default",
             "schemas": [
-                {"id": "default", "url": "file:///etc/config/identity.default.schema.json"}
+                {"id": "default", "url": "file:///etc/config/identity.default.schema.json"},
+                {"id": "admin", "url": "file:///etc/config/identity.admin.schema.json"},
             ],
         },
         "selfservice": {

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1016,7 +1016,7 @@ def test_run_migration(
 def test_error_on_run_migration(
     harness: Harness, mocked_kratos_is_running: MagicMock, mocked_run_migration: MagicMock
 ) -> None:
-    mocked_run_migration.return_value= (None, "Error")
+    mocked_run_migration.return_value = (None, "Error")
     event = MagicMock()
 
     harness.charm._on_run_migration_action(event)

--- a/tests/unit/test_kratos.py
+++ b/tests/unit/test_kratos.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 import json

--- a/tests/unit/test_kratos.py
+++ b/tests/unit/test_kratos.py
@@ -1,3 +1,6 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 import json
 from typing import Dict, Tuple
 from unittest.mock import MagicMock

--- a/tests/unit/test_kratos.py
+++ b/tests/unit/test_kratos.py
@@ -1,0 +1,215 @@
+import json
+from typing import Dict, Tuple
+from unittest.mock import MagicMock
+
+import pytest
+from ops.pebble import ExecError
+from pytest_mock import MockerFixture
+
+from kratos import KratosAPI
+
+
+@pytest.mark.parametrize(
+    "function_name,call_args",
+    [
+        ("create_identity", ({}, {})),
+        ("get_identity", ("id",)),
+        ("delete_identity", ("id",)),
+        ("list_identities", ()),
+        ("get_identity_from_email", ("mail",)),
+        ("run_migration", ()),
+    ],
+)
+def test_pebble_exec_error(
+    kratos_api: KratosAPI,
+    function_name: str,
+    call_args: Tuple,
+):
+    kratos_api.container.exec.side_effect = ExecError(
+        command=["some", "command"], exit_code=1, stdout="", stderr="Error"
+    )
+
+    with pytest.raises(ExecError):
+        getattr(kratos_api, function_name)(*call_args)
+
+
+def test_create_identity(
+    kratos_api: KratosAPI, kratos_identity_json: Dict, mocked_kratos_process: MagicMock
+):
+    mocked_kratos_process.wait_output.return_value = (json.dumps(kratos_identity_json), None)
+    traits = {
+        "email": kratos_identity_json["traits"]["email"],
+    }
+    schema_id = "user"
+    expected_stdin = json.dumps(dict(traits=traits, schema_id=schema_id))
+
+    kratos_api.create_identity(traits, schema_id)
+
+    assert kratos_api.container.exec.call_args[0][0] == [
+        "kratos",
+        "import",
+        "identities",
+        "--endpoint",
+        kratos_api.kratos_admin_url,
+        "--format",
+        "json",
+    ]
+    mocked_kratos_process.stdin.write.assert_called_with(expected_stdin)
+
+
+def test_create_identity_with_password(
+    kratos_api: KratosAPI, kratos_identity_json: Dict, mocked_kratos_process: MagicMock
+):
+    mocked_kratos_process.wait_output.return_value = (json.dumps(kratos_identity_json), None)
+    traits = {
+        "email": kratos_identity_json["traits"]["email"],
+    }
+    schema_id = "user"
+    password = "pass"
+    expected_stdin = json.dumps(
+        dict(
+            traits=traits,
+            schema_id=schema_id,
+            credentials={"password": {"config": {"password": password}}},
+        )
+    )
+
+    kratos_api.create_identity(traits, schema_id, password=password)
+
+    assert kratos_api.container.exec.call_args[0][0] == [
+        "kratos",
+        "import",
+        "identities",
+        "--endpoint",
+        kratos_api.kratos_admin_url,
+        "--format",
+        "json",
+    ]
+    mocked_kratos_process.stdin.write.assert_called_with(expected_stdin)
+
+
+def test_get_identity(
+    kratos_api: KratosAPI, kratos_identity_json: Dict, mocked_kratos_process: MagicMock
+):
+    mocked_kratos_process.wait_output.return_value = (json.dumps(kratos_identity_json), None)
+
+    kratos_api.get_identity(identity_id := kratos_identity_json["id"])
+
+    assert kratos_api.container.exec.call_args[0][0] == [
+        "kratos",
+        "get",
+        "identity",
+        "--endpoint",
+        kratos_api.kratos_admin_url,
+        "--format",
+        "json",
+        identity_id,
+    ]
+
+
+def test_delete_identity(
+    kratos_api: KratosAPI, kratos_identity_json: Dict, mocked_kratos_process: MagicMock
+):
+    mocked_kratos_process.wait_output.return_value = (json.dumps(kratos_identity_json), None)
+
+    kratos_api.delete_identity(identity_id := kratos_identity_json["id"])
+
+    assert kratos_api.container.exec.call_args[0][0] == [
+        "kratos",
+        "delete",
+        "identity",
+        "--endpoint",
+        kratos_api.kratos_admin_url,
+        "--format",
+        "json",
+        identity_id,
+    ]
+
+
+def test_list_identities(
+    kratos_api: KratosAPI, kratos_identity_json: Dict, mocked_kratos_process: MagicMock
+):
+    mocked_kratos_process.wait_output.return_value = (json.dumps([kratos_identity_json]), None)
+
+    kratos_api.list_identities()
+
+    assert kratos_api.container.exec.call_args[0][0] == [
+        "kratos",
+        "list",
+        "identities",
+        "--endpoint",
+        kratos_api.kratos_admin_url,
+        "--format",
+        "json",
+    ]
+
+
+def test_get_identity_from_email(
+    kratos_api: KratosAPI, kratos_identity_json: Dict, mocked_kratos_process: MagicMock
+):
+    mocked_kratos_process.wait_output.return_value = (json.dumps([kratos_identity_json]), None)
+
+    identity = kratos_api.get_identity_from_email(kratos_identity_json["traits"]["email"])
+
+    assert kratos_api.container.exec.call_args[0][0] == [
+        "kratos",
+        "list",
+        "identities",
+        "--endpoint",
+        kratos_api.kratos_admin_url,
+        "--format",
+        "json",
+    ]
+    assert identity == kratos_identity_json
+
+
+def test_get_identity_from_email_with_wrong_mail(
+    kratos_api: KratosAPI, kratos_identity_json: Dict, mocked_kratos_process: MagicMock
+):
+    mocked_kratos_process.wait_output.return_value = (json.dumps([kratos_identity_json]), None)
+
+    identity = kratos_api.get_identity_from_email("mail")
+
+    assert identity is None
+
+
+def test_recover_password_with_code(
+    kratos_api: KratosAPI, mocker: MockerFixture, recover_password_with_code_resp: Dict
+):
+    mocked_resp = MagicMock()
+    mocked_resp.json.return_value = recover_password_with_code_resp
+    mocker.patch("requests.post", return_value=mocked_resp)
+
+    ret = kratos_api.recover_password_with_code("identity_id")
+
+    assert ret == recover_password_with_code_resp
+
+
+def test_recover_password_with_link(
+    kratos_api: KratosAPI, mocker: MockerFixture, recover_password_with_link_resp: Dict
+):
+    mocked_resp = MagicMock()
+    mocked_resp.json.return_value = recover_password_with_link_resp
+    mocker.patch("requests.post", return_value=mocked_resp)
+
+    ret = kratos_api.recover_password_with_link("identity_id")
+
+    assert ret == recover_password_with_link_resp
+
+
+def test_run_migration(
+    kratos_api: KratosAPI, kratos_identity_json: Dict, mocked_kratos_process: MagicMock
+):
+    mocked_kratos_process.wait_output.return_value = (json.dumps([kratos_identity_json]), None)
+
+    kratos_api.run_migration()
+
+    assert kratos_api.container.exec.call_args[0][0] == [
+        "kratos",
+        "migrate",
+        "sql",
+        "-e",
+        "--config",
+        kratos_api.config_file_path,
+        "--yes",
+    ]

--- a/unit-requirements.txt
+++ b/unit-requirements.txt
@@ -1,4 +1,5 @@
 pytest
 pytest-mock
 coverage[toml]
+ipdb
 -r requirements.txt


### PR DESCRIPTION
- [x] The `reset-password` and `create-admin-account` (without a password provided) will not work until we implement the settings and recovery endpoints, should we just comment the actions out until that happens?
- [x] The `run-migration` action is not sufficiently tested, perhaps we should open an issue to look into that in the future