### PR TITLE
 Convert ingress provided URLs to https

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,12 +3,6 @@ options:
     description: SMTP connection URI
     type: string
     default: 'smtps://test:test@mailslurper:1025/?skip_ssl_verify=true'
-  external_url:
-    description:
-      The URL under which Kratos is externally reachable (for example,
-      if Kratos is served via a reverse proxy).
-    type: string
-    default: ""
   dev:
     description:
       Run Kratos on dev mode, it is needed if HTTPS is not set up. This should only be used for development purposes.

--- a/src/charm.py
+++ b/src/charm.py
@@ -205,9 +205,7 @@ class KratosCharm(CharmBase):
 
     @property
     def _domain_url(self) -> Optional[str]:
-        return (
-            normalise_url(self.public_ingress.url) if self.public_ingress.is_ready() else None
-        )
+        return normalise_url(self.public_ingress.url) if self.public_ingress.is_ready() else None
 
     @cached_property
     def _get_available_mappers(self) -> List[str]:

--- a/src/utils.py
+++ b/src/utils.py
@@ -44,6 +44,7 @@ def normalise_url(url: str) -> str:
     1) The ingress will serve https under the 443 port, the user-agent will
        implicitly make the request on that port
     2) The provided URL is not a relative path
+    3) No user/password is provided in the netloc
 
     This is a hack and should be removed once traefik provides a way for us to
     request the https URL.

--- a/src/utils.py
+++ b/src/utils.py
@@ -9,7 +9,16 @@ from urllib.parse import urlparse, urlunparse
 
 
 def dict_to_action_output(d: Dict) -> Dict:
-    """Convert all keys in a dict to the format of a juju action output."""
+    """Convert all keys in a dict to the format of a juju action output.
+
+    All `_` in the keys are replaced with `-`. This is applied recursively
+    to any nested dicts.
+
+    For example:
+        {"a_b_c": 123} -> {"a-b-c": 123}
+        {"a_b": {"c_d": "aba"}} -> {"a-b": {"c-d": "aba"}}
+
+    """
     ret = {}
     for k, v in d.items():
         k = k.replace("_", "-")
@@ -20,11 +29,16 @@ def dict_to_action_output(d: Dict) -> Dict:
 
 
 def normalise_url(url: str) -> str:
-    """Convert a URL to a more userfriendly format.
+    """Convert a URL to a more user friendly HTTPS URL.
 
     The user will be redirected to this URL, we need to use the https prefix
     in order to be able to set cookies (secure attribute is set). Also we remove
     the port from the URL to make it more user-friendly.
+
+    For example:
+        http://ingress:80 -> https://ingress
+        http://ingress:80/ -> https://ingress/
+        http://ingress:80/path/subpath -> https://ingress/path/subpath
 
     This conversion works under the following assumptions:
     1) The ingress will serve https under the 443 port, the user-agent will

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Utility functions for the Kratos charm."""
+
+from typing import Dict
+from urllib.parse import urlparse, urlunparse
+
+
+def dict_to_action_output(d: Dict) -> Dict:
+    """Convert all keys in a dict to the format of a juju action output."""
+    ret = {}
+    for k, v in d.items():
+        k = k.replace("_", "-")
+        if isinstance(v, dict):
+            v = dict_to_action_output(v)
+        ret[k] = v
+    return ret
+
+
+def normalise_url(url: str) -> str:
+    """Convert a URL to a more userfriendly format.
+
+    The user will be redirected to this URL, we need to use the https prefix
+    in order to be able to set cookies (secure attribute is set). Also we remove
+    the port from the URL to make it more user-friendly.
+
+    This conversion works under the following assumptions:
+    1) The ingress will serve https under the 443 port, the user-agent will
+       implicitly make the request on that port
+    2) The provided URL is not a relative path
+
+    This is a hack and should be removed once traefik provides a way for us to
+    request the https URL.
+    """
+    p = urlparse(url)
+
+    p = p._replace(scheme="https")
+    p = p._replace(netloc=p.netloc.rsplit(":", 1)[0])
+
+    return urlunparse(p)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -651,7 +651,7 @@ def test_on_client_config_changed_with_ingress(
         },
         "serve": {
             "public": {
-                "base_url": "http://public:80/kratos-model-kratos",
+                "base_url": "https://public/kratos-model-kratos",
                 "cors": {
                     "enabled": True,
                 },
@@ -659,6 +659,7 @@ def test_on_client_config_changed_with_ingress(
         },
     }
     expected_schemas = expected_config["identity"].pop("schemas")
+    expected_redirect_url = harness.charm.public_ingress.url.replace("http://", "https://").replace(":80", "")
 
     app_data = json.loads(harness.get_relation_data(relation_id, harness.charm.app)["providers"])
 
@@ -668,99 +669,7 @@ def test_on_client_config_changed_with_ingress(
     assert all(schema in schemas for schema in expected_schemas)
     assert len(expected_schemas) == len(schemas)
     assert config == expected_config
-    assert app_data[0]["redirect_uri"].startswith(harness.charm.public_ingress.url)
-
-
-def test_on_client_config_changed_with_external_url_config(
-    harness: Harness, mocked_container: Container
-) -> None:
-    # This is the provider id that will be computed based on the provider config
-    provider_id = "generic_9d07bcc95549089d7f16120e8bed5396469a5426"
-    harness.update_config({"external_url": "https://example.com"})
-    setup_postgres_relation(harness)
-    (login_relation_id, login_databag) = setup_login_ui_relation(harness)
-
-    relation_id = setup_external_provider_relation(harness)
-    container = harness.model.unit.get_container(CONTAINER_NAME)
-
-    expected_config = {
-        "log": {"level": "trace"},
-        "identity": {
-            "default_schema_id": "social_user_v0",
-            "schemas": [
-                {"id": "admin_v0", "url": "file:///etc/config/schemas/default/admin_v0.json"},
-                {
-                    "id": "social_user_v0",
-                    "url": "file:///etc/config/schemas/default/social_user_v0.json",
-                },
-            ],
-        },
-        "selfservice": {
-            "default_browser_return_url": login_databag["default_url"],
-            "flows": {
-                "error": {
-                    "ui_url": login_databag["error_url"],
-                },
-                "login": {
-                    "ui_url": login_databag["login_url"],
-                },
-                "registration": {
-                    "enabled": True,
-                    "ui_url": login_databag["registration_url"],
-                    "after": {"oidc": {"hooks": [{"hook": "session"}]}},
-                },
-            },
-            "methods": {
-                "password": {
-                    "enabled": False,
-                },
-                "oidc": {
-                    "config": {
-                        "providers": [
-                            {
-                                "id": provider_id,
-                                "client_id": "client_id",
-                                "client_secret": "client_secret",
-                                "issuer_url": "https://example.com/oidc",
-                                "mapper_url": "file:///etc/config/claim_mappers/default_schema.jsonnet",
-                                "provider": "generic",
-                                "scope": ["profile", "email", "address", "phone"],
-                            },
-                        ],
-                    },
-                    "enabled": True,
-                },
-            },
-        },
-        "dsn": f"postgres://{DB_USERNAME}:{DB_PASSWORD}@{DB_ENDPOINTS}/kratos-model_kratos",
-        "courier": {
-            "smtp": {"connection_uri": "smtps://test:test@mailslurper:1025/?skip_ssl_verify=true"}
-        },
-        "serve": {
-            "public": {
-                "base_url": "https://example.com",
-                "cors": {
-                    "enabled": True,
-                },
-            },
-        },
-    }
-    expected_schemas = expected_config["identity"].pop("schemas")
-
-    app_data = json.loads(harness.get_relation_data(relation_id, harness.charm.app)["providers"])
-
-    container_config = container.pull(path="/etc/config/kratos.yaml", encoding="utf-8")
-    config = yaml.load(container_config.read(), yaml.Loader)
-    schemas = config["identity"].pop("schemas")
-    assert all(schema in schemas for schema in expected_schemas)
-    assert len(expected_schemas) == len(schemas)
-    assert config == expected_config
-    assert app_data == [
-        {
-            "provider_id": provider_id,
-            "redirect_uri": f'{harness.charm.config["external_url"]}/self-service/methods/oidc/callback/{provider_id}',
-        }
-    ]
+    assert app_data[0]["redirect_uri"].startswith(expected_redirect_url)
 
 
 def test_on_client_config_changed_with_hydra(harness: Harness) -> None:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -659,7 +659,9 @@ def test_on_client_config_changed_with_ingress(
         },
     }
     expected_schemas = expected_config["identity"].pop("schemas")
-    expected_redirect_url = harness.charm.public_ingress.url.replace("http://", "https://").replace(":80", "")
+    expected_redirect_url = harness.charm.public_ingress.url.replace(
+        "http://", "https://"
+    ).replace(":80", "")
 
     app_data = json.loads(harness.get_relation_data(relation_id, harness.charm.app)["providers"])
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -4,7 +4,7 @@
 from utils import dict_to_action_output, normalise_url
 
 
-def test_dict_to_action_output():
+def test_dict_to_action_output() -> None:
     dic = {"a_b_c": 123}
     expected_dict = {"a-b-c": 123}
 
@@ -13,7 +13,7 @@ def test_dict_to_action_output():
     assert expected_dict == out
 
 
-def test_dict_to_action_output_with_nested_dict():
+def test_dict_to_action_output_with_nested_dict() -> None:
     dic = {"a_b": {"c_d": "aba"}}
     expected_dict = {"a-b": {"c-d": "aba"}}
 
@@ -22,7 +22,7 @@ def test_dict_to_action_output_with_nested_dict():
     assert expected_dict == out
 
 
-def test_dict_to_action_output_without_underscore():
+def test_dict_to_action_output_without_underscore() -> None:
     dic = {"a!@##$%^&*()-+=b": {"c123d": "aba"}}
 
     out = dict_to_action_output(dic)
@@ -30,7 +30,7 @@ def test_dict_to_action_output_without_underscore():
     assert dic == out
 
 
-def test_dict_to_action_output_with_empty_dict():
+def test_dict_to_action_output_with_empty_dict() -> None:
     dic = {}
 
     out = dict_to_action_output(dic)
@@ -38,7 +38,7 @@ def test_dict_to_action_output_with_empty_dict():
     assert dic == out
 
 
-def test_normalise_url_with_subpatch():
+def test_normalise_url_with_subpatch() -> None:
     url = "http://ingress:80/path/subpath"
     expected_url = "https://ingress/path/subpath"
 
@@ -47,7 +47,7 @@ def test_normalise_url_with_subpatch():
     assert res_url == expected_url
 
 
-def test_normalise_url_without_subpatch():
+def test_normalise_url_without_subpatch() -> None:
     url = "http://ingress:80/"
     expected_url = "https://ingress/"
 
@@ -56,7 +56,7 @@ def test_normalise_url_without_subpatch():
     assert res_url == expected_url
 
 
-def test_normalise_url_without_trailing_slash():
+def test_normalise_url_without_trailing_slash() -> None:
     url = "http://ingress:80"
     expected_url = "https://ingress"
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,65 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from utils import dict_to_action_output, normalise_url
+
+
+def test_dict_to_action_output():
+    dic = {"a_b_c": 123}
+    expected_dict = {"a-b-c": 123}
+
+    out = dict_to_action_output(dic)
+
+    assert expected_dict == out
+
+
+def test_dict_to_action_output_with_nested_dict():
+    dic = {"a_b": {"c_d": "aba"}}
+    expected_dict = {"a-b": {"c-d": "aba"}}
+
+    out = dict_to_action_output(dic)
+
+    assert expected_dict == out
+
+
+def test_dict_to_action_output_without_underscore():
+    dic = {"a!@##$%^&*()-+=b": {"c123d": "aba"}}
+
+    out = dict_to_action_output(dic)
+
+    assert dic == out
+
+
+def test_dict_to_action_output_with_empty_dict():
+    dic = {}
+
+    out = dict_to_action_output(dic)
+
+    assert dic == out
+
+
+def test_normalise_url_with_subpatch():
+    url = "http://ingress:80/path/subpath"
+    expected_url = "https://ingress/path/subpath"
+
+    res_url = normalise_url(url)
+
+    assert res_url == expected_url
+
+
+def test_normalise_url_without_subpatch():
+    url = "http://ingress:80/"
+    expected_url = "https://ingress/"
+
+    res_url = normalise_url(url)
+
+    assert res_url == expected_url
+
+
+def test_normalise_url_without_trailing_slash():
+    url = "http://ingress:80"
+    expected_url = "https://ingress"
+
+    res_url = normalise_url(url)
+
+    assert res_url == expected_url


### PR DESCRIPTION
- Convert ingress provided URLs to https and remove the port.
- Remove `external_url` config.

