### PR TITLE
fix: fixed issue around the log file directory

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -515,11 +515,11 @@ class KratosCharm(CharmBase):
         # Necessary directory for log forwarding
         if not self._container.can_connect():
             event.defer()
-            logger.info("Cannot connect to Hydra container. Deferring event.")
             self.unit.status = WaitingStatus("Waiting to connect to Kratos container")
             return
         if not self._container.isdir(str(self._log_dir)):
-            self._container.make_dir(path=str(self._log_dir), make_parents=True, permissions=0o755)
+            self._container.make_dir(path=str(self._log_dir), make_parents=True)
+            logger.info(f"Created directory {self._log_dir}")
 
         self._handle_status_update_config(event)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -107,8 +107,8 @@ class KratosCharm(CharmBase):
         self._prometheus_scrape_relation_name = "metrics-endpoint"
         self._loki_push_api_relation_name = "logging"
         self._kratos_service_command = "kratos serve all"
-        self._log_path = "/var/log/kratos.log"
         self._log_dir = "/var/log"
+        self._log_path = f"{self._log_dir}/kratos.log"
 
         self.kratos = KratosAPI(
             f"http://127.0.0.1:{KRATOS_ADMIN_PORT}", self._container, str(self._config_file_path)

--- a/src/charm.py
+++ b/src/charm.py
@@ -519,7 +519,7 @@ class KratosCharm(CharmBase):
             self.unit.status = WaitingStatus("Waiting to connect to Kratos container")
             return
         if not self._container.isdir(str(self._log_dir)):
-            self._container.make_dir(path=str(self._log_dir), make_parents=True, permissions=0o777)
+            self._container.make_dir(path=str(self._log_dir), make_parents=True, permissions=0o755)
 
         self._handle_status_update_config(event)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -108,6 +108,7 @@ class KratosCharm(CharmBase):
         self._loki_push_api_relation_name = "logging"
         self._kratos_service_command = "kratos serve all"
         self._log_path = "/var/log/kratos.log"
+        self._log_dir = "/var/log"
 
         self.kratos = KratosAPI(
             f"http://127.0.0.1:{KRATOS_ADMIN_PORT}", self._container, str(self._config_file_path)
@@ -499,6 +500,8 @@ class KratosCharm(CharmBase):
             return
 
         self._push_default_files()
+        if not self._container.isdir(self._log_dir):
+            self._container.make_dir(path=self._log_dir, make_parents=True, permissions=0o777)
 
     def _on_leader_elected(self, event: LeaderElectedEvent) -> None:
         if not self.unit.is_leader():

--- a/src/charm.py
+++ b/src/charm.py
@@ -107,8 +107,8 @@ class KratosCharm(CharmBase):
         self._prometheus_scrape_relation_name = "metrics-endpoint"
         self._loki_push_api_relation_name = "logging"
         self._kratos_service_command = "kratos serve all"
-        self._log_dir = "/var/log"
-        self._log_path = f"{self._log_dir}/kratos.log"
+        self._log_dir = Path("/var/log")
+        self._log_path = self._log_dir / "kratos.log"
 
         self.kratos = KratosAPI(
             f"http://127.0.0.1:{KRATOS_ADMIN_PORT}", self._container, str(self._config_file_path)
@@ -167,7 +167,7 @@ class KratosCharm(CharmBase):
 
         self.loki_consumer = LogProxyConsumer(
             self,
-            log_files=[self._log_path],
+            log_files=[str(self._log_path)],
             relation_name=self._loki_push_api_relation_name,
             container_name=self._container_name,
         )
@@ -239,7 +239,9 @@ class KratosCharm(CharmBase):
                     "summary": "Kratos Operator layer",
                     "startup": "disabled",
                     "command": '/bin/sh -c "{} {} 2>&1 | tee -a {}"'.format(
-                        self._kratos_service_command, self._kratos_service_params, self._log_path
+                        self._kratos_service_command,
+                        self._kratos_service_params,
+                        str(self._log_path),
                     ),
                 }
             },
@@ -516,8 +518,8 @@ class KratosCharm(CharmBase):
             logger.info("Cannot connect to Hydra container. Deferring event.")
             self.unit.status = WaitingStatus("Waiting to connect to Kratos container")
             return
-        if not self._container.isdir(self._log_dir):
-            self._container.make_dir(path=self._log_dir, make_parents=True, permissions=0o777)
+        if not self._container.isdir(str(self._log_dir)):
+            self._container.make_dir(path=str(self._log_dir), make_parents=True, permissions=0o777)
 
         self._handle_status_update_config(event)
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -211,3 +211,15 @@ def mocked_log_proxy_consumer_setup_promtail(mocker: MockerFixture) -> MagicMock
         "charms.loki_k8s.v0.loki_push_api.LogProxyConsumer._setup_promtail", return_value=None
     )
     return mocked_setup_promtail
+
+
+@pytest.fixture()
+def mocked_isdir(mocker: MockerFixture) -> MagicMock:
+    mocked_isdir = mocker.patch("ops.Container.isdir", return_value=False)
+    return mocked_isdir
+
+
+@pytest.fixture()
+def mocked_make_dir(mocker: MockerFixture) -> MagicMock:
+    mocked_make_dir = mocker.patch("ops.Container.make_dir", return_value=None)
+    return mocked_make_dir

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -211,15 +211,3 @@ def mocked_log_proxy_consumer_setup_promtail(mocker: MockerFixture) -> MagicMock
         "charms.loki_k8s.v0.loki_push_api.LogProxyConsumer._setup_promtail", return_value=None
     )
     return mocked_setup_promtail
-
-
-@pytest.fixture()
-def mocked_isdir(mocker: MockerFixture) -> MagicMock:
-    mocked_isdir = mocker.patch("ops.Container.isdir", return_value=False)
-    return mocked_isdir
-
-
-@pytest.fixture()
-def mocked_make_dir(mocker: MockerFixture) -> MagicMock:
-    mocked_make_dir = mocker.patch("ops.Container.make_dir", return_value=None)
-    return mocked_make_dir

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1293,7 +1293,7 @@ def test_on_pebble_ready_make_dir_called(
     harness.charm.on.kratos_pebble_ready.emit(container)
 
     mocked_isdir.assert_called_once_with("/var/log")
-    mocked_make_dir.assert_called_once_with(path="/var/log", make_parents=True, permissions=0o777)
+    mocked_make_dir.assert_called_once_with(path="/var/log", make_parents=True, permissions=0o755)
 
 
 def test_on_pebble_ready_cannot_connect_container_make_dir_not_called(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1286,23 +1286,8 @@ def test_on_config_changed_with_invalid_log_level(harness: Harness) -> None:
     assert "Invalid configuration value for log_level" in harness.charm.unit.status.message
 
 
-def test_on_pebble_ready_make_dir_called(
-    harness: Harness, mocked_isdir: MagicMock, mocked_make_dir: MagicMock
-) -> None:
+def test_on_pebble_ready_make_dir_called(harness: Harness) -> None:
     container = harness.model.unit.get_container(CONTAINER_NAME)
     harness.charm.on.kratos_pebble_ready.emit(container)
 
-    mocked_isdir.assert_called_once_with("/var/log")
-    mocked_make_dir.assert_called_once_with(path="/var/log", make_parents=True)
-
-
-def test_on_pebble_ready_cannot_connect_container_make_dir_not_called(
-    harness: Harness, mocked_isdir: MagicMock, mocked_make_dir: MagicMock
-) -> None:
-    harness.set_can_connect(CONTAINER_NAME, False)
-    container = harness.model.unit.get_container(CONTAINER_NAME)
-    harness.charm.on.kratos_pebble_ready.emit(container)
-
-    assert harness.model.unit.status == WaitingStatus("Waiting to connect to Kratos container")
-    mocked_isdir.assert_not_called
-    mocked_make_dir.assert_not_called
+    assert container.isdir("/var/log")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1284,3 +1284,25 @@ def test_on_config_changed_with_invalid_log_level(harness: Harness) -> None:
 
     assert isinstance(harness.model.unit.status, BlockedStatus)
     assert "Invalid configuration value for log_level" in harness.charm.unit.status.message
+
+
+def test_on_pebble_ready_make_dir_called(
+    harness: Harness, mocked_isdir: MagicMock, mocked_make_dir: MagicMock
+) -> None:
+    container = harness.model.unit.get_container(CONTAINER_NAME)
+    harness.charm.on.kratos_pebble_ready.emit(container)
+
+    mocked_isdir.assert_called_once_with("/var/log")
+    mocked_make_dir.assert_called_once_with(path="/var/log", make_parents=True, permissions=0o777)
+
+
+def test_on_pebble_ready_cannot_connect_container_make_dir_not_called(
+    harness: Harness, mocked_isdir: MagicMock, mocked_make_dir: MagicMock
+) -> None:
+    harness.set_can_connect(CONTAINER_NAME, False)
+    container = harness.model.unit.get_container(CONTAINER_NAME)
+    harness.charm.on.kratos_pebble_ready.emit(container)
+
+    assert harness.model.unit.status == WaitingStatus("Waiting to connect to Kratos container")
+    mocked_isdir.assert_not_called
+    mocked_make_dir.assert_not_called

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1293,7 +1293,7 @@ def test_on_pebble_ready_make_dir_called(
     harness.charm.on.kratos_pebble_ready.emit(container)
 
     mocked_isdir.assert_called_once_with("/var/log")
-    mocked_make_dir.assert_called_once_with(path="/var/log", make_parents=True, permissions=0o755)
+    mocked_make_dir.assert_called_once_with(path="/var/log", make_parents=True)
 
 
 def test_on_pebble_ready_cannot_connect_container_make_dir_not_called(


### PR DESCRIPTION
Fixed the issue of directory in log file path not being present in rock. Manually verified to work.

To test:
- deploy kratos
- deploy loki
- integrate kratos with loki
- after entering ```curl loki_url:3100/loki/api/v1/label/juju_unit/values``` command you should see the kratos unit you deployed