### PR TITLE
Add login and sessions endpoints to kratos lib

### DIFF
--- a/lib/charms/kratos/v0/kratos_endpoints.py
+++ b/lib/charms/kratos/v0/kratos_endpoints.py
@@ -51,7 +51,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 RELATION_NAME = "kratos-endpoint-info"
 INTERFACE_NAME = "kratos_endpoints"

--- a/src/charm.py
+++ b/src/charm.py
@@ -533,14 +533,14 @@ class KratosCharm(CharmBase):
         admin_endpoint = (
             self.admin_ingress.url
             if self.admin_ingress.is_ready()
-            else f"http://{self.app.name}.{self.model.name}.svc.cluster.local:{KRATOS_ADMIN_PORT}",
+            else f"http://{self.app.name}.{self.model.name}.svc.cluster.local:{KRATOS_ADMIN_PORT}"
         )
         public_endpoint = (
             self.public_ingress.url
             if self.public_ingress.is_ready()
-            else f"http://{self.app.name}.{self.model.name}.svc.cluster.local:{KRATOS_PUBLIC_PORT}",
+            else f"http://{self.app.name}.{self.model.name}.svc.cluster.local:{KRATOS_PUBLIC_PORT}"
         )
-        self.endpoints_provider.send_endpoint_relation_data(admin_endpoint[0], public_endpoint[0])
+        self.endpoints_provider.send_endpoint_relation_data(admin_endpoint, public_endpoint)
 
     def _on_database_created(self, event: DatabaseCreatedEvent) -> None:
         """Event Handler for database created event."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -833,6 +833,8 @@ def test_kratos_endpoint_info_relation_data_without_ingress_relation_data(
     expected_data = {
         "admin_endpoint": "http://kratos.kratos-model.svc.cluster.local:4434",
         "public_endpoint": "http://kratos.kratos-model.svc.cluster.local:4433",
+        "login_browser_endpoint": "http://kratos.kratos-model.svc.cluster.local:4433/self-service/login/browser",
+        "sessions_endpoint": "http://kratos.kratos-model.svc.cluster.local:4433/sessions/whoami",
     }
 
     assert harness.get_relation_data(endpoint_info_relation_id, "kratos") == expected_data


### PR DESCRIPTION
- adds login browser and sessions endpoints to the `kratos_endpoints` library
- uses ingress (if relation provided) instead of service to communicate with other components, since oathkeeper and kratos can be in different models.