### PR TITLE
fix: Kratos fails to restart when cluster reboots

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -148,8 +148,6 @@ class KratosCharm(CharmBase):
 
         self.endpoints_provider = KratosEndpointsProvider(self)
 
-        self.framework.observe(self.on.install, self._on_install)
-
         self.metrics_endpoint = MetricsEndpointProvider(
             self,
             relation_name=self._prometheus_scrape_relation_name,
@@ -172,6 +170,7 @@ class KratosCharm(CharmBase):
             container_name=self._container_name,
         )
 
+        self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.kratos_pebble_ready, self._on_pebble_ready)
         self.framework.observe(self.on.leader_elected, self._on_leader_elected)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
@@ -497,7 +496,7 @@ class KratosCharm(CharmBase):
     def _on_install(self, event: InstallEvent) -> None:
         if not self._container.can_connect():
             event.defer()
-            logger.info("Cannot connect to Kratos container. Deferring event.")
+            logger.info("Cannot connect to Kratos container. Deferring install event.")
             self.unit.status = WaitingStatus("Waiting to connect to Kratos container")
             return
 
@@ -521,6 +520,7 @@ class KratosCharm(CharmBase):
             self._container.make_dir(path=str(self._log_dir), make_parents=True)
             logger.info(f"Created directory {self._log_dir}")
 
+        self._push_default_files()
         self._handle_status_update_config(event)
 
     def _on_config_changed(self, event: ConfigChangedEvent) -> None:

--- a/src/kratos.py
+++ b/src/kratos.py
@@ -104,10 +104,8 @@ class KratosAPI:
         This will fetch all identities and iterate over them in memory.
         """
         ids = self.list_identities()
-        id = list(filter(lambda identity: identity["traits"].get("email") == email, ids))
-        if not id:
-            return None
-        return id[0]
+        id_ = [identity for identity in ids if identity["traits"].get("email") == email]
+        return id_[0] if id_ else None
 
     def recover_password_with_code(self, identity_id: str, expires_in: str = "1h") -> Dict:
         """Create a one time code for recovering an identity's password."""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -211,3 +211,9 @@ def mocked_log_proxy_consumer_setup_promtail(mocker: MockerFixture) -> MagicMock
         "charms.loki_k8s.v0.loki_push_api.LogProxyConsumer._setup_promtail", return_value=None
     )
     return mocked_setup_promtail
+
+
+@pytest.fixture()
+def mocked_push_default_files(mocker: MockerFixture) -> MagicMock:
+    mocked = mocker.patch("charm.KratosCharm._push_default_files")
+    return mocked


### PR DESCRIPTION
### Context

This pull request tries to resolve the issue https://github.com/canonical/kratos-operator/issues/84.

### Solution

We push the default schema files mappers in the callback function for `pebble_ready` event to cover the cluster restart scenario.