### PR TITLE
Install jsonschema from binary

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -14,3 +14,5 @@ parts:
     prime:
       - claim_mappers/**
       - identity_schemas/**
+    charm-binary-python-packages:
+      - jsonschema


### PR DESCRIPTION
Fixes charmcraft packing, latest jsonschema version requires rust causing `pip install` to fail