### PR TITLE
IAM-209-Add alert rules to Kratos Operator

### DIFF
--- a/src/loki_alert_rules/kratos_high_severity_log.rule
+++ b/src/loki_alert_rules/kratos_high_severity_log.rule
@@ -2,37 +2,37 @@ groups:
 - name: KratosHighSeverityLog
   rules:
   - alert: ErrorLevelLog
-    expr: sum(count_over_time({%%juju_topology%%} |= `"severity":"error"` [5m])) < 100 and sum(count_over_time({%%juju_topology%%} |= `"severity":"error"` [5m])) > 0
+    expr: sum(count_over_time({%%juju_topology%%} |= `"level":"error"` [5m])) < 100 and sum(count_over_time({%%juju_topology%%} |= `"level":"error"` [5m])) > 0
     labels:
       severity: warning
     annotations:
       message: "Logs with level error found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level error is low."
   - alert: ErrorLevelLogHighFrequency
-    expr: sum(count_over_time({%%juju_topology%%} |= `"severity":"error"` [5m])) > 100
+    expr: sum(count_over_time({%%juju_topology%%} |= `"level":"error"` [5m])) > 100
     labels:
       severity: error
     annotations:
       summary: "Logs with level error found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level error is high."
   - alert: CriticalLevelLog
-    expr: sum(count_over_time({%%juju_topology%%} |= `"severity":"critical"` [5m])) < 100 and sum(count_over_time({%%juju_topology%%} |= `"severity":"critical"` [5m])) > 0
+    expr: sum(count_over_time({%%juju_topology%%} |= `"level":"critical"` [5m])) < 100 and sum(count_over_time({%%juju_topology%%} |= `"level":"critical"` [5m])) > 0
     labels:
       severity: warning
     annotations:
       message: "Logs with level critical found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level critical is low."
   - alert: CriticalLevelLogHighFrequency
-    expr: sum(count_over_time({%%juju_topology%%} |= `"severity":"critical"` [5m])) > 100
+    expr: sum(count_over_time({%%juju_topology%%} |= `"level":"critical"` [5m])) > 100
     labels:
       severity: error
     annotations:
       summary: "Logs with level critical found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level critical is high."
   - alert: FatalLevelLog
-    expr: sum(count_over_time({%%juju_topology%%} |= `"severity":"fatal"` [5m])) < 100 and sum(count_over_time({%%juju_topology%%} |= `"severity":"fatal"` [5m])) > 0
+    expr: sum(count_over_time({%%juju_topology%%} |= `"level":"fatal"` [5m])) < 100 and sum(count_over_time({%%juju_topology%%} |= `"level":"fatal"` [5m])) > 0
     labels:
       severity: warning
     annotations:
       message: "Logs with level fatal found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level critical is low."
   - alert: FatalLevelLogHighFrequency
-    expr: sum(count_over_time({%%juju_topology%%} |= `"severity":"fatal"` [5m])) > 100
+    expr: sum(count_over_time({%%juju_topology%%} |= `"level":"fatal"` [5m])) > 100
     labels:
       severity: error
     annotations:

--- a/src/loki_alert_rules/kratos_high_severity_log.rule
+++ b/src/loki_alert_rules/kratos_high_severity_log.rule
@@ -1,0 +1,39 @@
+groups:
+- name: KratosHighSeverityLog
+  rules:
+  - alert: ErrorLevelLog
+    expr: sum(count_over_time({%%juju_topology%%} |= `"severity":"error"` [5m])) < 100 and sum(count_over_time({%%juju_topology%%} |= `"severity":"error"` [5m])) > 0
+    labels:
+      severity: warning
+    annotations:
+      message: "Logs with level error found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level error is low."
+  - alert: ErrorLevelLogHighFrequency
+    expr: sum(count_over_time({%%juju_topology%%} |= `"severity":"error"` [5m])) > 100
+    labels:
+      severity: error
+    annotations:
+      summary: "Logs with level error found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level error is high."
+  - alert: CriticalLevelLog
+    expr: sum(count_over_time({%%juju_topology%%} |= `"severity":"critical"` [5m])) < 100 and sum(count_over_time({%%juju_topology%%} |= `"severity":"critical"` [5m])) > 0
+    labels:
+      severity: warning
+    annotations:
+      message: "Logs with level critical found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level critical is low."
+  - alert: CriticalLevelLogHighFrequency
+    expr: sum(count_over_time({%%juju_topology%%} |= `"severity":"critical"` [5m])) > 100
+    labels:
+      severity: error
+    annotations:
+      summary: "Logs with level critical found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level critical is high."
+  - alert: FatalLevelLog
+    expr: sum(count_over_time({%%juju_topology%%} |= `"severity":"fatal"` [5m])) < 100 and sum(count_over_time({%%juju_topology%%} |= `"severity":"fatal"` [5m])) > 0
+    labels:
+      severity: warning
+    annotations:
+      message: "Logs with level fatal found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level critical is low."
+  - alert: FatalLevelLogHighFrequency
+    expr: sum(count_over_time({%%juju_topology%%} |= `"severity":"fatal"` [5m])) > 100
+    labels:
+      severity: error
+    annotations:
+      summary: "Logs with level fatal found in application {{ $labels.juju_application }} of Juju charm {{ $labels.juju_charm }} in model {{ $labels.juju_model }}. Frequency of logs with level fatal is high."

--- a/src/prometheus_alert_rules/kratos_unavailable.rule
+++ b/src/prometheus_alert_rules/kratos_unavailable.rule
@@ -1,0 +1,31 @@
+groups:
+- name: KratosUnavailable
+  rules:
+  - alert: KratosUnavailable-one
+    expr: sum(up) + 1 == count(up)
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      summary: "One unit of {{ $labels.juju_application }} in model {{ $labels.juju_model }} is down"
+  - alert: KratosUnavailable-multiple
+    expr: sum(up) + 1 < count(up)
+    for: 1m
+    labels:
+      severity: error
+    annotations:
+      summary: "Multiple units of {{ $labels.juju_application }} in model {{ $labels.juju_model }} are down"
+  - alert: KratosUnavailable-all-except-one
+    expr: sum(up) == 1 and 1 < count(up)
+    for: 1m
+    labels:
+      severity: critical
+    annotations:
+      summary: "All but one unit of {{ $labels.juju_application }} in model {{ $labels.juju_model }} are down"
+  - alert: KratosUnavailable-all
+    expr: sum(up) == 0
+    for: 1m
+    labels:
+      severity: fatal
+    annotations:
+      summary: "All units of {{ $labels.juju_application }} in model {{ $labels.juju_model }} are down"


### PR DESCRIPTION
Added alert rules to Kratos. Alert rules are verifiable on the grafana html user interface.

# TESTING


To verify Kratos alerts, you will need the cos-lite bundle:
```
juju deploy cos-lite --trust
```

Pack and deploy Kratos (in operator root directory), and its backend:

```
juju deploy postgresql-k8s --trust
charmcraft pack
juju deploy ./kratos*.charm  --resource oci-image=$(yq eval '.resources.oci-image.upstream-source' metadata.yaml) --trust
juju integrate kratos postgresql-k8s
```

# Integrations:

You need to integrate kratos with prometheus, loki:

```
juju integrate kratos prometheus
juju integrate kratos loki
```

Access Grafana's UI with your browser. The url is grafana-ip:3000. Username is admin, you can get the password with `juju run grafana/0 get-admin-password`

On the Grafana interface you should be able to find options bar on the left side of the screen. Go to alerts. There you will see the available alerts from prometheus and loki. You can open them up with the arrow on the left to see more details, or to open a graph mapping the result of the alert query over time.