### PR TITLE
IAM-395 Update Tracing relation

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -32,6 +32,11 @@ requires:
     limit: 1
   logging:
     interface: loki_push_api
+  tracing:
+    interface: tracing
+    limit: 1
+    description: |
+      Provides traces to COS Tempo instance
 peers:
   kratos-peers:
     interface: kratos-peers
@@ -48,8 +53,3 @@ provides:
     description: |
       Forwards the built-in grafana dashboard(s) for monitoring kratos.
     interface: grafana_dashboard
-  tracing:
-    interface: tracing
-    limit: 1
-    description: |
-      Provides traces to COS Tempo instance

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1369,11 +1369,14 @@ def test_layer_updated_with_tracing_endpoint_info(harness: Harness) -> None:
     harness.set_leader(True)
     harness.set_can_connect(CONTAINER_NAME, True)
     harness.charm.on.kratos_pebble_ready.emit(CONTAINER_NAME)
-    tracing_relation_id = setup_tempo_relation(harness)
+    setup_tempo_relation(harness)
 
     pebble_env = harness.charm._pebble_layer.to_dict()["services"][CONTAINER_NAME]["environment"]
 
-    assert pebble_env["TRACING_PROVIDERS_OTLP_SERVER_URL"] == "tempo-k8s-0.tempo-k8s-endpoints.namespace.svc.cluster.local:4318"
+    assert (
+        pebble_env["TRACING_PROVIDERS_OTLP_SERVER_URL"]
+        == "tempo-k8s-0.tempo-k8s-endpoints.namespace.svc.cluster.local:4318"
+    )
     assert pebble_env["TRACING_PROVIDERS_OTLP_INSECURE"]
     assert pebble_env["TRACING_PROVIDERS_OTLP_SAMPLING_SAMPLING_RATIO"] == 1
     assert pebble_env["TRACING_PROVIDER"] == "otel"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -11,7 +11,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 import yaml
-from charms.tempo_k8s.v0.tracing import Ingester, TracingRequirerAppData
 from ops.model import ActiveStatus, BlockedStatus, Container, WaitingStatus
 from ops.pebble import ExecError, TimeoutError
 from ops.testing import Harness
@@ -148,29 +147,18 @@ def setup_loki_relation(harness: Harness) -> int:
     return relation_id
 
 
-def setup_tracing_relation(harness: Harness) -> int:
+def setup_tempo_relation(harness: Harness) -> int:
     relation_id = harness.add_relation("tracing", "tempo-k8s")
     harness.add_relation_unit(relation_id, "tempo-k8s/0")
-
-    appdata = TracingRequirerAppData(
-        host="tempo-k8s-0.tempo-k8s-endpoints.testing.svc.cluster.local",
-        ingesters=[
-            Ingester(protocol="tempo", port=3200),
-            Ingester(protocol="otlp_grpc", port=4317),
-            Ingester(protocol="otlp_http", port=4318),
-            Ingester(protocol="zipkin", port=9411),
-        ],
-    )
-
-    databag = {}
-    appdata.dump(databag)
-
+    trace_databag = {
+        "host": '"tempo-k8s-0.tempo-k8s-endpoints.namespace.svc.cluster.local"',
+        "ingesters": '[{"protocol": "tempo", "port": 3200}, {"protocol": "otlp_grpc", "port": 4317}, {"protocol": "otlp_http", "port": 4318}, {"protocol": "zipkin", "port": 9411}, {"protocol": "jaeger_http_thrift", "port": 14268}, {"protocol": "jaeger_grpc", "port": 14250}]',
+    }
     harness.update_relation_data(
         relation_id,
         "tempo-k8s",
-        databag,
+        trace_databag,
     )
-
     return relation_id
 
 
@@ -1381,17 +1369,11 @@ def test_layer_updated_with_tracing_endpoint_info(harness: Harness) -> None:
     harness.set_leader(True)
     harness.set_can_connect(CONTAINER_NAME, True)
     harness.charm.on.kratos_pebble_ready.emit(CONTAINER_NAME)
-    tracing_relation_id = setup_tracing_relation(harness)
+    tracing_relation_id = setup_tempo_relation(harness)
 
     pebble_env = harness.charm._pebble_layer.to_dict()["services"][CONTAINER_NAME]["environment"]
 
-    relation = harness.get_relation_data(tracing_relation_id, "tempo-k8s")
-
-    appdata = TracingRequirerAppData.load(relation)
-
-    http = [i.port for i in appdata.ingesters if i.protocol == "otlp_http"][0]
-
-    assert pebble_env["TRACING_PROVIDERS_OTLP_SERVER_URL"] == f"{appdata.host}:{http}"
+    assert pebble_env["TRACING_PROVIDERS_OTLP_SERVER_URL"] == "tempo-k8s-0.tempo-k8s-endpoints.namespace.svc.cluster.local:4318"
     assert pebble_env["TRACING_PROVIDERS_OTLP_INSECURE"]
     assert pebble_env["TRACING_PROVIDERS_OTLP_SAMPLING_SAMPLING_RATIO"] == 1
     assert pebble_env["TRACING_PROVIDER"] == "otel"


### PR DESCRIPTION
This pr updates the tracing integration to the Kratos Operator.

---

Testing:
The tracing configurations for kratos are in envars.
A unit test is in there to make sure that the correct pebble layer gets rendered after relation with tempo.

# Manual Test
You will need to deploy tempo-k8s, kratos operator, postgresql-k8s, grafana-k8s to verify the that tracing is working.
Integrate kratos with the data backend, then with tempo-k8s.
```
juju integrate kratos tempo-k8s
```
Integrate tempo-k8s with grafana as a grafana source:
```
juju integrate tempo-k8s grafana-k8s:grafana-source
```

Open grafana in the browser: grafana_ip:3000
login name: admin
to get password run:
```
juju run grafana-k8s/0 get-admin-password
```

Go to the explore button in the menu. Pick tempo as the data source. Set the query type to search. Enter Ory Kratos to Service Name. Start Query. If you see results the integration was succesful.