### PR TITLE
fix: use http endpoint in kratos-endpoint-info integration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,22 +2,28 @@
 
 ## Overview
 
-This document explains the processes and practices recommended for contributing enhancements to
-this operator.
+This document explains the processes and practices recommended for contributing
+enhancements to this operator.
 
-- Generally, before developing bugs or enhancements to this charm, you should [open an issue
-  ](https://github.com/canonical/kratos-operator/issues) explaining your use case.
+- Generally, before developing bugs or enhancements to this charm, you
+  should [open an issue](https://github.com/canonical/kratos-operator/issues)
+  explaining your use case.
 - If you would like to chat with us about charm development, you can reach
-  us at [Canonical Mattermost public channel](https://chat.charmhub.io/charmhub/channels/charm-dev)
+  us
+  at [Canonical Mattermost public channel](https://chat.charmhub.io/charmhub/channels/charm-dev)
   or [Discourse](https://discourse.charmhub.io/).
-- Familiarising yourself with the [Charmed Operator Framework](https://juju.is/docs/sdk) library
+- Familiarising yourself with
+  the [Charmed Operator Framework](https://juju.is/docs/sdk) library
   will help you a lot when working on new features or bug fixes.
-- All enhancements require review before being merged. Code review typically examines
-  - code quality
-  - test coverage
-  - user experience for Juju administrators of this charm.
-- Please help us out in ensuring easy to review branches by rebasing your pull request branch onto
-  the `main` branch. This also avoids merge commits and creates a linear Git commit history.
+- All enhancements require review before being merged. Code review typically
+  examines:
+    - code quality
+    - test coverage
+    - user experience for Juju administrators of this charm.
+- Please help us out in ensuring easy to review branches by rebasing your pull
+  request branch onto the `main` branch. This also avoids merge commits and
+  creates a linear Git
+  commit history.
 
 ## Developing
 
@@ -48,8 +54,7 @@ charmcraft pack
 
 ### Deploy
 
-
-```bash
+```shell
 # Create a model
 juju add-model dev
 # Enable DEBUG logging
@@ -60,4 +65,6 @@ juju deploy ./kratos_ubuntu-*-amd64.charm --resource oci-image=$(yq eval '.resou
 
 ## Canonical Contributor Agreement
 
-Canonical welcomes contributions to Charmed Ory Kratos. Please check out our [contributor agreement](https://ubuntu.com/legal/contributors) if you're interested in contributing to the solution.
+Canonical welcomes contributions to Charmed Ory Kratos. Please check out
+our [contributor agreement](https://ubuntu.com/legal/contributors) if you're
+interested in contributing to the solution.

--- a/src/utils.py
+++ b/src/utils.py
@@ -5,7 +5,7 @@
 """Utility functions for the Kratos charm."""
 
 from typing import Dict
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import urlparse
 
 
 def dict_to_action_output(d: Dict) -> Dict:
@@ -29,7 +29,7 @@ def dict_to_action_output(d: Dict) -> Dict:
 
 
 def normalise_url(url: str) -> str:
-    """Convert a URL to a more user friendly HTTPS URL.
+    """Convert a URL to a more user-friendly HTTPS URL.
 
     The user will be redirected to this URL, we need to use the https prefix
     in order to be able to set cookies (secure attribute is set). Also we remove
@@ -49,9 +49,9 @@ def normalise_url(url: str) -> str:
     This is a hack and should be removed once traefik provides a way for us to
     request the https URL.
     """
-    p = urlparse(url)
+    parsed_url = urlparse(url)
 
-    p = p._replace(scheme="https")
-    p = p._replace(netloc=p.netloc.rsplit(":", 1)[0])
+    parsed_url = parsed_url._replace(scheme="https")
+    parsed_url = parsed_url._replace(netloc=parsed_url.netloc.rsplit(":", 1)[0])
 
-    return urlunparse(p)
+    return parsed_url.geturl()


### PR DESCRIPTION
This pull request aims to provide public endpoints with HTTP protocol in the `kratos-endpoint-info` integration.

**Note:** pls ignore the changes in the CONTRIBUTING.md. It's just formatting changes.