### PR TITLE
Fix automerge

### DIFF
--- a/.github/workflows/auto-approver.yaml
+++ b/.github/workflows/auto-approver.yaml
@@ -1,5 +1,5 @@
-name: renovate-approve
-run-name: CI for approving renovate PRs
+name: auto-approver
+run-name: CI for approving PRs
 
 on:
   push:
@@ -16,3 +16,8 @@ jobs:
           gh pr review --approve || true
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+      - name: Enable automerge if required
+        run: |
+          if [[ $(gh pr view --json body | grep "\*\*Automerge\*\*: Enabled") ]]; then
+            gh pr merge --auto --merge
+          fi


### PR DESCRIPTION
The approver bot will now enable auto merge is required. For some reason the renovate PRs didn't have it turned on even if enabled.