### PR TITLE
Improve migration logic

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -199,6 +199,9 @@ class KratosCharm(CharmBase):
         )
         self.framework.observe(self.database.on.database_created, self._on_database_created)
         self.framework.observe(self.database.on.endpoints_changed, self._on_database_changed)
+        self.framework.observe(
+            self.on[self._db_relation_name].relation_broken, self._on_database_removed
+        )
         self.framework.observe(self.admin_ingress.on.ready, self._on_admin_ingress_ready)
         self.framework.observe(self.admin_ingress.on.revoked, self._on_ingress_revoked)
         self.framework.observe(self.public_ingress.on.ready, self._on_public_ingress_ready)
@@ -672,6 +675,11 @@ class KratosCharm(CharmBase):
 
     def _on_database_changed(self, event: DatabaseEndpointsChangedEvent) -> None:
         """Event Handler for database changed event."""
+        self._handle_status_update_config(event)
+
+    def _on_database_removed(self, event: DatabaseEndpointsChangedEvent) -> None:
+        """Event Handler for database changed event."""
+        self._pop_peer_data(PEER_KEY_DB_MIGRATE_VERSION)
         self._handle_status_update_config(event)
 
     def _on_admin_ingress_ready(self, event: IngressPerAppReadyEvent) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -654,8 +654,7 @@ class KratosCharm(CharmBase):
             return
 
         if not self._migration_is_needed():
-            self._container.start(self._container_name)
-            self.unit.status = ActiveStatus()
+            self._handle_status_update_config(event)
             return
 
         if not self.unit.is_leader():
@@ -670,8 +669,7 @@ class KratosCharm(CharmBase):
             return
 
         self._set_peer_data(PEER_KEY_DB_MIGRATE_VERSION, self.kratos.get_version())
-        self._container.start(self._container_name)
-        self.unit.status = ActiveStatus()
+        self._handle_status_update_config(event)
 
     def _on_database_changed(self, event: DatabaseEndpointsChangedEvent) -> None:
         """Event Handler for database changed event."""

--- a/src/kratos.py
+++ b/src/kratos.py
@@ -137,6 +137,21 @@ class KratosAPI:
         ]
         return self._run_cmd(cmd, timeout=timeout)
 
+    def get_version(self) -> str:
+        """Get the version of the kratos binary."""
+        cmd = ["kratos", "version"]
+
+        stdout = self._run_cmd(cmd)
+
+        # Output has the format:
+        # Version:    {version}
+        # Build Commit:   {hash}
+        # Build Timestamp: {time}
+        out_re = r"Version:\s*(.+)\nBuild Commit:\s*(.+)\nBuild Timestamp:\s*(.+)"
+        versions = re.findall(out_re, stdout)[0]
+
+        return versions[0]
+
     def _run_cmd(self, cmd: List[str], timeout: float = 20, input_: Optional[str] = None) -> str:
         logger.debug(f"Running cmd: {cmd}")
         process = self.container.exec(cmd, timeout=timeout)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -131,6 +131,27 @@ def kratos_identity_json() -> Dict:
 
 
 @pytest.fixture()
+def mocked_migration_is_needed(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("charm.KratosCharm._migration_is_needed", return_value=False)
+
+
+@pytest.fixture()
+def mocked_get_secret(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("charm.KratosCharm._get_secret", return_value={"cookie": "secret"})
+
+
+@pytest.fixture(autouse=True)
+def mocked_get_version(mocker: MockerFixture) -> MagicMock:
+    mock = mocker.patch("charm.KratosAPI.get_version", return_value=None)
+    mock.return_value = {
+        "version": "1.0.1",
+        "git_hash": "fasd23541235123321dfsdgsadg",
+        "build_time": "2023-06-13 16:42:24.609532580+03:00",
+    }
+    return mock
+
+
+@pytest.fixture()
 def mocked_get_identity(mocker: MockerFixture, kratos_identity_json: Dict) -> MagicMock:
     mock = mocker.patch("charm.KratosAPI.get_identity", return_value=kratos_identity_json)
     return mock

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -690,14 +690,17 @@ def test_on_client_config_changed_when_no_dns_available(harness: Harness) -> Non
 
 
 def test_on_client_config_changed_with_ingress(
-    harness: Harness, mocked_container: Container
+    harness: Harness, mocked_container: Container, mocked_migration_is_needed: MagicMock
 ) -> None:
+    setup_peer_relation(harness)
     setup_postgres_relation(harness)
     setup_ingress_relation(harness, "public")
     (_, login_databag) = setup_login_ui_relation(harness)
 
     relation_id, data = setup_external_provider_relation(harness)
     container = harness.model.unit.get_container(CONTAINER_NAME)
+    harness.charm.on.leader_elected.emit()
+    harness.charm.on.kratos_pebble_ready.emit(container)
 
     expected_config = {
         "log": {

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -15,8 +15,6 @@ from ops.model import ActiveStatus, BlockedStatus, Container, WaitingStatus
 from ops.pebble import ExecError, TimeoutError
 from ops.testing import Harness
 
-from charm import DB_MIGRATE_VERSION, PEER_KEY_DB_MIGRATE_VERSION
-
 CONFIG_DIR = Path("/etc/config")
 CONTAINER_NAME = "kratos"
 DB_USERNAME = "fake_relation_id_1"
@@ -70,11 +68,6 @@ def setup_ingress_relation(harness: Harness, type: str) -> int:
 def setup_peer_relation(harness: Harness) -> None:
     rel_id = harness.add_relation("kratos-peers", "kratos")
     harness.add_relation_unit(rel_id, "kratos/1")
-    harness.update_relation_data(
-        rel_id,
-        "kratos",
-        {PEER_KEY_DB_MIGRATE_VERSION: DB_MIGRATE_VERSION},
-    )
 
 
 def setup_hydra_relation(harness: Harness) -> int:
@@ -251,8 +244,12 @@ def test_on_pebble_ready_cannot_connect_container(harness: Harness) -> None:
     assert isinstance(harness.model.unit.status, WaitingStatus)
 
 
-def test_on_pebble_ready_correct_plan(harness: Harness) -> None:
+def test_on_pebble_ready_correct_plan(
+    harness: Harness, mocked_migration_is_needed: MagicMock, mocked_get_secret: MagicMock
+) -> None:
     container = harness.model.unit.get_container(CONTAINER_NAME)
+    setup_peer_relation(harness)
+    setup_postgres_relation(harness)
     harness.charm.on.kratos_pebble_ready.emit(container)
 
     expected_plan = {
@@ -270,10 +267,15 @@ def test_on_pebble_ready_correct_plan(harness: Harness) -> None:
 
 
 def test_on_pebble_ready_correct_plan_with_dev_flag(
-    harness: Harness, caplog: pytest.LogCaptureFixture
+    harness: Harness,
+    mocked_migration_is_needed: MagicMock,
+    mocked_get_secret: MagicMock,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     harness.update_config({"dev": True})
     container = harness.model.unit.get_container(CONTAINER_NAME)
+    setup_peer_relation(harness)
+    setup_postgres_relation(harness)
     harness.charm.on.kratos_pebble_ready.emit(container)
 
     expected_plan = {
@@ -291,20 +293,21 @@ def test_on_pebble_ready_correct_plan_with_dev_flag(
     assert "Running Kratos in dev mode, don't do this in production" in caplog.messages
 
 
-def test_on_pebble_ready_service_not_started_when_database_not_created(harness: Harness) -> None:
+def test_on_pebble_ready_service_does_not_exist_when_database_not_created(
+    harness: Harness,
+) -> None:
     container = harness.model.unit.get_container(CONTAINER_NAME)
     harness.charm.on.kratos_pebble_ready.emit(container)
 
-    service = harness.model.unit.get_container("kratos").get_service("kratos")
-    assert not service.is_running()
+    assert "kratos" not in harness.model.unit.get_container("kratos").get_services()
 
 
-def test_on_pebble_ready_service_started_when_database_is_created(harness: Harness) -> None:
-    setup_postgres_relation(harness)
-    setup_peer_relation(harness)
-
+def test_on_pebble_ready_service_started_when_database_is_created(
+    harness: Harness, mocked_migration_is_needed: MagicMock, mocked_get_secret: MagicMock
+) -> None:
     container = harness.model.unit.get_container(CONTAINER_NAME)
-    harness.charm.on.leader_elected.emit()
+    setup_peer_relation(harness)
+    setup_postgres_relation(harness)
     harness.charm.on.kratos_pebble_ready.emit(container)
 
     service = harness.model.unit.get_container("kratos").get_service("kratos")
@@ -390,8 +393,14 @@ def test_on_pebble_ready_push_default_files(
     mocked_push_default_files.assert_called_once()
 
 
-def test_on_config_changed_when_identity_schemas_config(harness: Harness) -> None:
+def test_on_config_changed_when_identity_schemas_config(
+    harness: Harness, mocked_migration_is_needed: MagicMock
+) -> None:
+    setup_peer_relation(harness)
     setup_postgres_relation(harness)
+    container = harness.model.unit.get_container(CONTAINER_NAME)
+    harness.charm.on.leader_elected.emit()
+    harness.charm.on.kratos_pebble_ready.emit(container)
     schema_id = "user_v0"
     harness.update_config(
         dict(
@@ -435,11 +444,19 @@ def test_on_config_changed_when_identity_schemas_config(harness: Harness) -> Non
         },
     }
 
-    validate_config(expected_config, yaml.safe_load(harness.charm._render_conf_file()))
+    container_config = container.pull(path="/etc/config/kratos.yaml", encoding="utf-8")
+    validate_config(expected_config, yaml.safe_load(container_config))
 
 
-def test_on_config_changed_when_identity_schemas_config_unset(harness: Harness) -> None:
+def test_on_config_changed_when_identity_schemas_config_unset(
+    harness: Harness, mocked_migration_is_needed: MagicMock
+) -> None:
+    setup_peer_relation(harness)
     setup_postgres_relation(harness)
+    container = harness.model.unit.get_container(CONTAINER_NAME)
+    harness.charm.on.leader_elected.emit()
+    harness.charm.on.kratos_pebble_ready.emit(container)
+
     schema_id = "user_v0"
     harness.update_config(
         dict(
@@ -481,7 +498,8 @@ def test_on_config_changed_when_identity_schemas_config_unset(harness: Harness) 
         },
     }
 
-    validate_config(expected_config, yaml.safe_load(harness.charm._render_conf_file()))
+    container_config = container.pull(path="/etc/config/kratos.yaml", encoding="utf-8")
+    validate_config(expected_config, yaml.safe_load(container_config))
 
 
 def test_on_database_created_cannot_connect_container(harness: Harness) -> None:
@@ -508,6 +526,7 @@ def test_on_database_created_updated_config_and_start_service_when_pebble_is_rea
     harness: Harness, mocked_pebble_exec_success: MagicMock
 ) -> None:
     container = harness.model.unit.get_container(CONTAINER_NAME)
+    harness.charm.on.leader_elected.emit()
     harness.charm.on.kratos_pebble_ready.emit(container)
     setup_peer_relation(harness)
     setup_postgres_relation(harness)
@@ -523,13 +542,14 @@ def test_on_database_created_updated_config_and_start_service_when_pebble_is_rea
 
 
 def test_on_database_created_updated_config_and_start_service_when_pebble_is_ready_in_non_leader_unit(
-    harness: Harness,
+    harness: Harness, mocked_get_secret: MagicMock, mocked_migration_is_needed: MagicMock
 ) -> None:
     harness.set_leader(False)
     container = harness.model.unit.get_container(CONTAINER_NAME)
-    harness.charm.on.kratos_pebble_ready.emit(container)
+    harness.charm.on.leader_elected.emit()
     setup_peer_relation(harness)
     setup_postgres_relation(harness)
+    harness.charm.on.kratos_pebble_ready.emit(container)
 
     service = harness.model.unit.get_container("kratos").get_service("kratos")
     assert service.is_running()
@@ -552,23 +572,26 @@ def test_on_database_created_not_run_migration_in_non_leader_unit(
     mocked_pebble_exec.assert_not_called()
 
 
-def test_on_database_created_pending_migration_in_non_leader_unit(harness: Harness) -> None:
+def test_on_database_created_pending_migration_in_non_leader_unit(
+    harness: Harness, mocked_get_secret: MagicMock
+) -> None:
     harness.set_leader(False)
     container = harness.model.unit.get_container(CONTAINER_NAME)
+    harness.charm.on.leader_elected.emit()
     harness.charm.on.kratos_pebble_ready.emit(container)
-    rel_id = harness.add_relation("kratos-peers", "kratos")
-    harness.add_relation_unit(rel_id, "kratos/1")
 
+    setup_peer_relation(harness)
     setup_postgres_relation(harness)
 
     assert isinstance(harness.charm.unit.status, WaitingStatus)
-    assert "Waiting for database migration to complete" in harness.charm.unit.status.message
+    assert "Unit waiting for leadership to run the migration" in harness.charm.unit.status.message
 
 
 def test_on_database_created_when_migration_is_successful(
     harness: Harness, mocked_pebble_exec_success: MagicMock
 ) -> None:
     container = harness.model.unit.get_container(CONTAINER_NAME)
+    harness.charm.on.leader_elected.emit()
     harness.charm.on.kratos_pebble_ready.emit(container)
     setup_peer_relation(harness)
     setup_postgres_relation(harness)
@@ -588,6 +611,7 @@ def test_on_database_created_when_migration_failed(
     harness: Harness, mocked_pebble_exec_failed: MagicMock
 ) -> None:
     container = harness.model.unit.get_container(CONTAINER_NAME)
+    harness.charm.on.leader_elected.emit()
     harness.charm.on.kratos_pebble_ready.emit(container)
     setup_peer_relation(harness)
     setup_postgres_relation(harness)
@@ -607,6 +631,7 @@ def test_on_database_changed_when_pebble_is_ready(
     harness: Harness, mocked_pebble_exec_success: MagicMock
 ) -> None:
     container = harness.model.unit.get_container(CONTAINER_NAME)
+    harness.charm.on.leader_elected.emit()
     harness.charm.on.kratos_pebble_ready.emit(container)
 
     setup_peer_relation(harness)
@@ -629,6 +654,7 @@ def test_on_config_changed_when_pebble_is_ready(
     harness: Harness, mocked_pebble_exec_success: MagicMock
 ) -> None:
     container = harness.model.unit.get_container(CONTAINER_NAME)
+    harness.charm.on.leader_elected.emit()
     harness.charm.on.kratos_pebble_ready.emit(container)
 
     setup_peer_relation(harness)
@@ -757,7 +783,10 @@ def test_on_client_config_changed_with_ingress(
     assert app_data[0]["redirect_uri"].startswith(expected_redirect_url)
 
 
-def test_on_client_config_changed_with_hydra(harness: Harness) -> None:
+def test_on_client_config_changed_with_hydra(
+    harness: Harness, mocked_migration_is_needed: MagicMock
+) -> None:
+    setup_peer_relation(harness)
     setup_postgres_relation(harness)
     (_, login_databag) = setup_login_ui_relation(harness)
 
@@ -815,7 +844,9 @@ def test_on_client_config_changed_with_hydra(harness: Harness) -> None:
     validate_config(expected_config, yaml.safe_load(container_config))
 
 
-def test_on_client_config_changed_when_missing_hydra_relation_data(harness: Harness) -> None:
+def test_on_client_config_changed_when_missing_hydra_relation_data(
+    harness: Harness, mocked_migration_is_needed: MagicMock
+) -> None:
     setup_postgres_relation(harness)
     setup_peer_relation(harness)
     (login_relation_id, login_databag) = setup_login_ui_relation(harness)
@@ -896,7 +927,10 @@ def test_kratos_endpoint_info_relation_data_without_ingress_relation_data(
     assert harness.get_relation_data(endpoint_info_relation_id, "kratos") == expected_data
 
 
-def test_on_client_config_changed_without_login_ui_endpoints(harness: Harness) -> None:
+def test_on_client_config_changed_without_login_ui_endpoints(
+    harness: Harness, mocked_migration_is_needed: MagicMock
+) -> None:
+    setup_peer_relation(harness)
     setup_postgres_relation(harness)
 
     container = harness.model.unit.get_container(CONTAINER_NAME)
@@ -948,7 +982,7 @@ def test_on_client_config_changed_without_login_ui_endpoints(harness: Harness) -
 
 
 def test_on_client_config_changed_when_missing_login_ui_and_hydra_relation_data(
-    harness: Harness,
+    harness: Harness, mocked_migration_is_needed: MagicMock
 ) -> None:
     setup_postgres_relation(harness)
     setup_peer_relation(harness)
@@ -1285,6 +1319,7 @@ def test_create_admin_account_without_password(
 def test_run_migration_action(
     harness: Harness, mocked_kratos_service: MagicMock, mocked_run_migration: MagicMock
 ) -> None:
+    setup_peer_relation(harness)
     event = MagicMock()
 
     harness.charm._on_run_migration_action(event)
@@ -1319,7 +1354,9 @@ def test_timeout_on_run_migration_action(
     event.fail.assert_called()
 
 
-def test_on_pebble_ready_with_loki(harness: Harness) -> None:
+def test_on_pebble_ready_with_loki(
+    harness: Harness, mocked_migration_is_needed: MagicMock
+) -> None:
     setup_postgres_relation(harness)
     setup_peer_relation(harness)
     container = harness.model.unit.get_container(CONTAINER_NAME)

--- a/tests/unit/test_kratos.py
+++ b/tests/unit/test_kratos.py
@@ -211,9 +211,9 @@ def test_run_migration(kratos_api: KratosAPI, mocked_kratos_process: MagicMock) 
         "migrate",
         "sql",
         "-e",
+        "--yes",
         "--config",
         kratos_api.config_file_path,
-        "--yes",
     ]
 
     assert expected_output == cmd_output


### PR DESCRIPTION
Improvements around the migration logic. The goal is to bring the Kratos charm closer to the logic in the Hydra charm.

Changes:
- JSON dump the contents in the peer relation, this will make backwards compatibility much easier to achieve. Currently the charm stores the migration version in the peer relation as a string: `{"db_migrate_version": "0.11.1"}`, after these changes the version will be json dumped: `{"db_migrate_version": '"0.11.1"'}`. This is a breaking change and will cause the charm to go to an error state if you try to upgrade from the previous version to this.
- Use DSN from env var to run migration instead of having to read the config file. This will make it much simpler to run the migrations once the configMap is introduced (we won't have to wait for the configMap to update in order to run the migrations).
- Do not start the service in the database_created hook, instead call `_handle_status_update_config` to start the service. This introduces a single function that will be responsible for starting the Kratos service. This is a small change, whose only purpose is to simplify the code and remove code duplication.