### PR TITLE
fix(loki-rule): improve error handling in json parsing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 # TODO: Remove when pr https://github.com/go-macaroon-bakery/py-macaroon-bakery/pull/95 gets merged
 macaroonbakery==1.3.2
-cosl
-ops>=2.0.0
-lightkube
-lightkube-models
-Jinja2
-jsonschema
-requests
+cosl==0.0.7
+ops==2.10.0
+lightkube===0.15.0
+lightkube-models==1.29.0.6
+Jinja2==3.1.3
+jsonschema==4.21.1
+requests==2.31.0
 tenacity==8.2.3

--- a/src/loki_alert_rules/kratos_high_severity_log.rule
+++ b/src/loki_alert_rules/kratos_high_severity_log.rule
@@ -2,7 +2,7 @@ groups:
 - name: KratosHighSeverityLog
   rules:
   - alert: HighFrequencyHighSeverityLog
-    expr: sum by(level) (count_over_time({%%juju_topology%%} | json | level =~ `error|fatal|critical` [5m])) > 100
+    expr: sum by(level) (count_over_time({%%juju_topology%%} | json | __error__ != "JSONParserErr" | level =~ `error|fatal|critical` [5m])) > 100
     labels:
       severity: error
     annotations:


### PR DESCRIPTION
# Description
This PR simply adds a LogQL `label filter` to avoid loki processing log entry that failed json parsing.

### Edit
This PR also fixes unit tests that failed due to breaking changes in new `ops` dependency.
Main dependencies are pinned now.