### PR TITLE
Add `kratos-info` interface

### DIFF
--- a/lib/charms/harness_extensions/v0/capture_events.py
+++ b/lib/charms/harness_extensions/v0/capture_events.py
@@ -1,0 +1,86 @@
+'''This is a library providing a utility for unittesting events fired on a
+Harness-ed Charm.
+
+Example usage:
+
+>>> from charms.harness_extensions.v0.capture_events import capture
+>>> with capture(RelationEvent) as captured:
+>>>     harness.add_relation('foo', 'remote')
+>>> assert captured.event.unit.name == 'remote'
+'''
+
+# The unique Charmhub library identifier, never change it
+LIBID = "9fcdab70e26d4eee9797c0e542ab397a"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 3
+
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from contextlib import contextmanager
+from typing import Generic, Iterator, Optional, Type, TypeVar
+
+from ops.charm import CharmBase
+from ops.framework import EventBase
+
+_T = TypeVar("_T", bound=EventBase)
+
+
+@contextmanager
+def capture_events(charm: CharmBase, *types: Type[EventBase]):
+    """Capture all events of type `*types` (using instance checks)."""
+    allowed_types = types or (EventBase,)
+
+    captured = []
+    _real_emit = charm.framework._emit
+
+    def _wrapped_emit(evt):
+        if isinstance(evt, allowed_types):
+            captured.append(evt)
+        return _real_emit(evt)
+
+    charm.framework._emit = _wrapped_emit  # type: ignore # noqa # ugly
+
+    yield captured
+
+    charm.framework._emit = _real_emit  # type: ignore # noqa # ugly
+
+
+class Captured(Generic[_T]):
+    """Object to type and expose return value of capture()."""
+
+    _event = None
+
+    @property
+    def event(self) -> Optional[_T]:
+        """Return the captured event."""
+        return self._event
+
+    @event.setter
+    def event(self, val: _T):
+        self._event = val
+
+
+@contextmanager
+def capture(charm: CharmBase, typ_: Type[_T] = EventBase) -> Iterator[Captured[_T]]:
+    """Capture exactly 1 event of type `typ_`.
+
+    Will raise if more/less events have been fired, or if the returned event
+    does not pass an instance check.
+    """
+    result = Captured()
+    with capture_events(charm, typ_) as captured:
+        if not captured:
+            yield result
+
+    assert len(captured) <= 1, f"too many events captured: {captured}"
+    assert len(captured) >= 1, f"no event of type {typ_} emitted."
+    event = captured[0]
+    assert isinstance(event, typ_), f"expected {typ_}, not {type(event)}"
+    result.event = event
+

--- a/lib/charms/kratos/v0/kratos_endpoints.py
+++ b/lib/charms/kratos/v0/kratos_endpoints.py
@@ -147,7 +147,7 @@ class KratosEndpointsRequirer(Object):
 
         if not data:
             logger.info("No relation data available.")
-            return
+            raise KratosEndpointsRelationDataMissingError("Missing relation data")
 
         if "public_endpoint" not in data:
             raise KratosEndpointsRelationDataMissingError(

--- a/lib/charms/kratos/v0/kratos_info.py
+++ b/lib/charms/kratos/v0/kratos_info.py
@@ -92,8 +92,8 @@ class KratosInfoProvider(Object):
         self,
         admin_endpoint: str,
         public_endpoint: str,
-        providers_cofigmap_name: str,
-        schemas_cofigmap_name: str,
+        providers_configmap_name: str,
+        schemas_configmap_name: str,
         configmaps_namespace: str,
     ) -> None:
         """Updates relation with endpoints and configmaps info."""
@@ -106,8 +106,8 @@ class KratosInfoProvider(Object):
             "public_endpoint": public_endpoint,
             "login_browser_endpoint": f"{public_endpoint}/self-service/login/browser",
             "sessions_endpoint": f"{public_endpoint}/sessions/whoami",
-            "providers_configmap_name": providers_cofigmap_name,
-            "schemas_configmap_name": schemas_cofigmap_name,
+            "providers_configmap_name": providers_configmap_name,
+            "schemas_configmap_name": schemas_configmap_name,
             "configmaps_namespace": configmaps_namespace,
         }
 

--- a/lib/charms/kratos/v0/kratos_info.py
+++ b/lib/charms/kratos/v0/kratos_info.py
@@ -1,39 +1,39 @@
 #!/usr/bin/env python3
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""This interface is deprecated in favor of kratos_info.
-Interface library for sharing kratos endpoints.
-This library provides a Python API for both requesting and providing public and admin endpoints.
+"""Interface library for sharing kratos info.
+This library provides a Python API for both requesting and providing kratos deployment info,
+such as endpoints, namespace and ConfigMap details.
 ## Getting Started
 To get started using the library, you need to fetch the library using `charmcraft`.
 ```shell
 cd some-charm
-charmcraft fetch-lib charms.kratos.v0.kratos_endpoints
+charmcraft fetch-lib charms.kratos.v0.kratos_info
 ```
 To use the library from the requirer side:
 In the `metadata.yaml` of the charm, add the following:
 ```yaml
 requires:
-  kratos-endpoint-info:
-    interface: kratos_endpoints
+  kratos-info:
+    interface: kratos_info
     limit: 1
 ```
 Then, to initialise the library:
 ```python
-from charms.kratos.v0.kratos_endpoints import (
-    KratosEndpointsRelationError,
-    KratosEndpointsRequirer,
+from charms.kratos.v0.kratos_info import (
+    KratosInfoRelationError,
+    KratosInfoRequirer,
 )
 Class SomeCharm(CharmBase):
     def __init__(self, *args):
-        self.kratos_endpoints_relation = KratosEndpointsRequirer(self)
+        self.kratos_info_relation = KratosInfoRequirer(self)
         self.framework.observe(self.on.some_event_emitted, self.some_event_function)
     def some_event_function():
         # fetch the relation info
         try:
-            kratos_data = self.kratos_endpoints_relation.get_kratos_endpoints()
-        except KratosEndpointsRelationError as error:
+            kratos_data = self.kratos_info_relation.get_kratos_info()
+        except KratosInfoRelationError as error:
             ...
 ```
 """
@@ -45,34 +45,34 @@ from ops.charm import CharmBase, RelationCreatedEvent
 from ops.framework import EventBase, EventSource, Object, ObjectEvents
 
 # The unique Charmhub library identifier, never change it
-LIBID = "5868b36df1c04c90b33f5e5557327162"
+LIBID = "40d36890fe6d40409ccee34aa9245d4a"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 1
 
-RELATION_NAME = "kratos-endpoint-info"
-INTERFACE_NAME = "kratos_endpoints"
+RELATION_NAME = "kratos-info"
+INTERFACE_NAME = "kratos_info"
 logger = logging.getLogger(__name__)
 
 
-class KratosEndpointsRelationReadyEvent(EventBase):
+class KratosInfoRelationReadyEvent(EventBase):
     """Event to notify the charm that the relation is ready."""
 
 
-class KratosEndpointsProviderEvents(ObjectEvents):
-    """Event descriptor for events raised by `KratosEndpointsProvider`."""
+class KratosInfoProviderEvents(ObjectEvents):
+    """Event descriptor for events raised by `KratosInfoProvider`."""
 
-    ready = EventSource(KratosEndpointsRelationReadyEvent)
+    ready = EventSource(KratosInfoRelationReadyEvent)
 
 
-class KratosEndpointsProvider(Object):
-    """Provider side of the kratos-endpoint-info relation."""
+class KratosInfoProvider(Object):
+    """Provider side of the kratos-info relation."""
 
-    on = KratosEndpointsProviderEvents()
+    on = KratosInfoProviderEvents()
 
     def __init__(self, charm: CharmBase, relation_name: str = RELATION_NAME):
         super().__init__(charm, relation_name)
@@ -82,43 +82,53 @@ class KratosEndpointsProvider(Object):
 
         events = self._charm.on[relation_name]
         self.framework.observe(
-            events.relation_created, self._on_provider_endpoint_relation_created
+            events.relation_created, self._on_info_provider_relation_created
         )
 
-    def _on_provider_endpoint_relation_created(self, event: RelationCreatedEvent) -> None:
+    def _on_info_provider_relation_created(self, event: RelationCreatedEvent) -> None:
         self.on.ready.emit()
 
-    def send_endpoint_relation_data(self, admin_endpoint: str, public_endpoint: str) -> None:
-        """Updates relation with endpoints info."""
+    def send_info_relation_data(
+        self,
+        admin_endpoint: str,
+        public_endpoint: str,
+        providers_cofigmap_name: str,
+        schemas_cofigmap_name: str,
+        configmaps_namespace: str,
+    ) -> None:
+        """Updates relation with endpoints and configmaps info."""
         if not self._charm.unit.is_leader():
             return
 
         relations = self.model.relations[self._relation_name]
-        endpoints_databag = {
+        info_databag = {
             "admin_endpoint": admin_endpoint,
             "public_endpoint": public_endpoint,
             "login_browser_endpoint": f"{public_endpoint}/self-service/login/browser",
             "sessions_endpoint": f"{public_endpoint}/sessions/whoami",
+            "providers_configmap_name": providers_cofigmap_name,
+            "schemas_configmap_name": schemas_cofigmap_name,
+            "configmaps_namespace": configmaps_namespace,
         }
+
         for relation in relations:
-            relation.data[self._charm.app].update(endpoints_databag)
+            relation.data[self._charm.app].update(info_databag)
 
 
-class KratosEndpointsRelationError(Exception):
+class KratosInfoRelationError(Exception):
     """Base class for the relation exceptions."""
-
     pass
 
 
-class KratosEndpointsRelationMissingError(KratosEndpointsRelationError):
+class KratosInfoRelationMissingError(KratosInfoRelationError):
     """Raised when the relation is missing."""
 
     def __init__(self) -> None:
-        self.message = "Missing kratos-endpoint-info relation with kratos"
+        self.message = "Missing kratos-info relation with kratos"
         super().__init__(self.message)
 
 
-class KratosEndpointsRelationDataMissingError(KratosEndpointsRelationError):
+class KratosInfoRelationDataMissingError(KratosInfoRelationError):
     """Raised when information is missing from the relation."""
 
     def __init__(self, message: str) -> None:
@@ -126,32 +136,27 @@ class KratosEndpointsRelationDataMissingError(KratosEndpointsRelationError):
         super().__init__(self.message)
 
 
-class KratosEndpointsRequirer(Object):
-    """Requirer side of the kratos-endpoint-info relation."""
+class KratosInfoRequirer(Object):
+    """Requirer side of the kratos-info relation."""
 
     def __init__(self, charm: CharmBase, relation_name: str = RELATION_NAME):
         super().__init__(charm, relation_name)
         self.charm = charm
         self.relation_name = relation_name
 
-    def get_kratos_endpoints(self) -> Optional[Dict]:
-        """Get the kratos endpoints."""
-        endpoints = self.model.relations[self.relation_name]
-        if len(endpoints) == 0:
-            raise KratosEndpointsRelationMissingError()
+    def get_kratos_info(self) -> Optional[Dict]:
+        """Get the kratos info."""
+        info = self.model.relations[self.relation_name]
+        if len(info) == 0:
+            raise KratosInfoRelationMissingError()
 
-        if not (app := endpoints[0].app):
-            raise KratosEndpointsRelationMissingError()
+        if not (app := info[0].app):
+            raise KratosInfoRelationMissingError()
 
-        data = endpoints[0].data[app]
+        data = info[0].data[app]
 
         if not data:
             logger.info("No relation data available.")
             return
-
-        if "public_endpoint" not in data:
-            raise KratosEndpointsRelationDataMissingError(
-                "Missing public endpoint in kratos-endpoint-info relation data"
-            )
 
         return data

--- a/lib/charms/kratos/v0/kratos_info.py
+++ b/lib/charms/kratos/v0/kratos_info.py
@@ -144,6 +144,13 @@ class KratosInfoRequirer(Object):
         self.charm = charm
         self.relation_name = relation_name
 
+    def is_ready(self) -> bool:
+        relation = self.model.get_relation(self.relation_name)
+        if not relation or not relation.app or not relation.data[relation.app]:
+            return False
+        return True
+
+
     def get_kratos_info(self) -> Optional[Dict]:
         """Get the kratos info."""
         info = self.model.relations[self.relation_name]

--- a/lib/charms/kratos/v0/kratos_info.py
+++ b/lib/charms/kratos/v0/kratos_info.py
@@ -157,6 +157,6 @@ class KratosInfoRequirer(Object):
 
         if not data:
             logger.info("No relation data available.")
-            return
+            raise KratosInfoRelationDataMissingError("Missing relation data")
 
         return data

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -46,6 +46,10 @@ provides:
     interface: kratos_endpoints
     description: |
       Provides API endpoints to a related application
+  kratos-info:
+    interface: kratos_info
+    description: |
+      Provides kratos deployment info to a related application
   metrics-endpoint:
     interface: prometheus_scrape
     description: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ profile = "black"
 max-line-length = 99
 max-doc-length = 99
 max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
+exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv", "tests/unit/capture_events.py"]
 select = ["E", "W", "F", "C", "N", "R", "D", "H"]
 # Ignore W503, E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__

--- a/src/charm.py
+++ b/src/charm.py
@@ -742,7 +742,7 @@ class KratosCharm(CharmBase):
             admin_endpoint,
             public_endpoint,
             providers_configmap_name,
-            schemas_cnofigmap_name,
+            schemas_configmap_name,
             configmaps_namespace,
         )
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -206,6 +206,7 @@ class KratosCharm(CharmBase):
         self.framework.observe(self.on.leader_elected, self._on_leader_elected)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.remove, self._on_remove)
+        # TODO: Remove once all charms use kratos-info instead of kratos-endpoints-info
         self.framework.observe(
             self.endpoints_provider.on.ready, self._update_kratos_endpoints_relation_data
         )
@@ -733,15 +734,15 @@ class KratosCharm(CharmBase):
         logger.info("Sending kratos info")
 
         (admin_endpoint, public_endpoint) = self._kratos_endpoints
-        providers_cofigmap_name = "providers"
-        schemas_cofigmap_name = "identity-schemas"
+        providers_configmap_name = self.providers_configmap.name
+        schemas_configmap_name = self.schemas_configmap.name
         configmaps_namespace = self.model.name
 
         self.info_provider.send_info_relation_data(
             admin_endpoint,
             public_endpoint,
-            providers_cofigmap_name,
-            schemas_cofigmap_name,
+            providers_configmap_name,
+            schemas_cnofigmap_name,
             configmaps_namespace,
         )
 

--- a/tests/unit/capture_events.py
+++ b/tests/unit/capture_events.py
@@ -1,4 +1,4 @@
-'''This is a library providing a utility for unittesting events fired on a
+"""This is a library providing a utility for unittesting events fired on a
 Harness-ed Charm.
 
 Example usage:
@@ -7,7 +7,7 @@ Example usage:
 >>> with capture(RelationEvent) as captured:
 >>>     harness.add_relation('foo', 'remote')
 >>> assert captured.event.unit.name == 'remote'
-'''
+"""
 
 # The unique Charmhub library identifier, never change it
 LIBID = "9fcdab70e26d4eee9797c0e542ab397a"
@@ -83,4 +83,3 @@ def capture(charm: CharmBase, typ_: Type[_T] = EventBase) -> Iterator[Captured[_
     event = captured[0]
     assert isinstance(event, typ_), f"expected {typ_}, not {type(event)}"
     result.event = event
-

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -238,12 +238,14 @@ def mocked_kratos_configmap(mocker: MockerFixture) -> MagicMock:
 def mocked_schemas_configmap(mocker: MockerFixture) -> MagicMock:
     mock = mocker.patch("charm.IdentitySchemaConfigMap", autospec=True)
     mock.return_value.get.return_value = {}
+    mock.return_value.name = "identity-schemas"
     return mock.return_value
 
 
 @pytest.fixture(autouse=True)
 def mocked_providers_configmap(mocker: MockerFixture) -> MagicMock:
     mock = mocker.patch("charm.ProvidersConfigMap", autospec=True)
+    mock.return_value.name = "providers"
     return mock.return_value
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -157,19 +157,6 @@ def setup_tempo_relation(harness: Harness) -> int:
 def setup_kratos_info_relation(harness: Harness) -> int:
     relation_id = harness.add_relation("kratos-info", "requirer")
     harness.add_relation_unit(relation_id, "requirer/0")
-    harness.update_relation_data(
-        relation_id,
-        "requirer",
-        {
-            "admin_endpoint": "https://admin-endpoint.com",
-            "public_endpoint": "https://public-endpoint.com",
-            "login_browser_endpoint": "https://public-endpoint.com/self-service/login/browser",
-            "sessions_endpoint": "https://public-endpoint.com/sessions/whoami",
-            "providers_cofigmap_name": "providers",
-            "schemas_cofigmap_name": "identity-schemas",
-            "configmaps_namespace": harness.model.name,
-        },
-    )
 
     return relation_id
 
@@ -1463,8 +1450,7 @@ def test_layer_updated_with_tracing_endpoint_info(harness: Harness) -> None:
 
 def test_kratos_info_ready_event_emitted_when_relation_created(harness: Harness) -> None:
     with capture_events(harness.charm, KratosInfoRelationReadyEvent) as captured:
-        relation_id = harness.add_relation("kratos-info", "requirer")
-        harness.add_relation_unit(relation_id, "requirer/0")
+        _ = setup_kratos_info_relation(harness)
 
     assert any(isinstance(e, KratosInfoRelationReadyEvent) for e in captured)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, Mock
 import pytest
 import requests
 import yaml
-from charms.harness_extensions.v0.capture_events import capture_events
+from capture_events import capture_events
 from charms.kratos.v0.kratos_info import KratosInfoRelationReadyEvent
 from ops.model import ActiveStatus, BlockedStatus, Container, WaitingStatus
 from ops.pebble import ExecError, TimeoutError


### PR DESCRIPTION
This PR adds a new `kratos-info` interface providing endpoints and configmaps details in a single relation.
It deprecates the `kratos-endpoint-info` interface which has a narrow scope.