### PR TITLE
chore: bump image version

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,7 +14,7 @@ resources:
   oci-image:
     type: oci-image
     description: Kratos oci-image
-    upstream-source: ghcr.io/canonical/kratos:1.0.0
+    upstream-source: ghcr.io/canonical/kratos:1.1.0
 requires:
   pg-database:
     interface: postgresql_client


### PR DESCRIPTION
This PR updates the kratos image version.
Note that v1.1.0 requires hydra 2.2.0 (see https://warthogs.atlassian.net/browse/IAM-699 for more context).