### PR TITLE
feat: add account management actions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,8 +31,7 @@ jobs:
         with:
           provider: microk8s
           channel: 1.28-strict/stable
-          juju-channel: 3.2
-          bootstrap-options: '--agent-version=3.2.0'
+          juju-channel: 3.4/stable
 
       - name: Run integration tests
         # set a predictable model name so it can be consumed by charm-logdump-action

--- a/README.md
+++ b/README.md
@@ -187,6 +187,67 @@ An email can be used to specify the identity as well:
 juju run kratos/0 delete-identity email={email}
 ```
 
+### reset-password
+
+This action can be used to reset password of an identity by its email or id.
+The password can be set to a specified value by passing `password-secret-id` as an action parameter.
+
+To create a juju secret holding the password and grant it to kratos, run:
+
+```shell
+juju add-secret <secret-name> password=<new-password>
+secret:cql684nmp25c75sflot0
+juju grant-secret <secret-name> kratos
+```
+
+Then, run the action using identity id:
+
+```shell
+juju run kratos/0 reset-password identity-id={identity_id} password-secret-id=secret:cql684nmp25c75sflot0
+```
+
+Or email:
+
+```shell
+juju run kratos/0 reset-password email={email} password-secret-id=secret:cql684nmp25c75sflot0
+```
+
+If `password-secret-id` parameter is not provided, the action will return a self-service recovery code and link
+to reset the password.
+
+### invalidate-identity-sessions
+
+This action can be used to invalidate all user sessions using either the identity id or email.
+
+By id:
+
+```shell
+juju run kratos/0 invalidate-identity-sessions identity-id={identity_id}
+```
+
+By email:
+
+```shell
+juju run kratos/0 invalidate-identity-sessions email={email}
+```
+
+### reset-identity-mfa
+
+This action can be used to reset identity's second authentication factor using either the identity id or email.
+The type of credentials to be removed must be specified, supported values are `totp` and `lookup_secret`.
+
+By id:
+
+```shell
+juju run kratos/0 reset-identity-mfa identity-id={identity_id} mfa-type={totp|lookup_secret}
+```
+
+By email:
+
+```shell
+juju run kratos/0 reset-identity-mfa email={email} mfa-type={totp|lookup_secret}
+```
+
 ### run-migration
 
 This action can be used to trigger a database migration:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -245,10 +245,15 @@ bases:
         channel: "22.04"
 
 parts:
-  charm:
+  schemas:
+    plugin: dump
+    source: .
+    organize:
+      "claim_mappers/**": schemas/
+      "identity_schemas/**": schemas/
     prime:
-      - claim_mappers/**
-      - identity_schemas/**
+      - schemas/
+  charm:
     charm-binary-python-packages:
       - jsonschema
       - bcrypt

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -188,8 +188,44 @@ actions:
       phone_number:
         description: The admin's phone number
         type: string
-    # TODO: Remove required password once password resetting is implemented
     required: ["username", "password"]
+  reset-password:
+    description: |
+      Reset password of an identity using either the identity ID or user email.
+      Required: one of `identity-id` or `email`
+    params:
+      identity-id:
+        description: The Identity ID
+        type: string
+      email:
+        description: The user's email
+        type: string
+      password:
+        description: The password to set for an identity. If not provided, a self-service recovery link will be returned.
+        type: string
+  invalidate-identity-sessions:
+    description: |
+      Invalidate all user sessions using either the identity ID or user email.
+    params:
+      identity-id:
+        description: The Identity ID
+        type: string
+      email:
+        description: The user's email
+        type: string
+  reset-identity-mfa:
+    description: |
+      Reset identity's second authentication factor using either the identity ID or user email.
+    params:
+      identity-id:
+        description: The Identity ID
+        type: string
+      email:
+        description: The user's email
+        type: string
+      mfa-type:
+        description: The type of credentials to be removed, one of `totp` or `lookup_secret`.
+        type: string
   run-migration:
     description: |
       Run a migration, this is needed after upgrades. This is a non-reversible operation.
@@ -215,3 +251,4 @@ parts:
       - identity_schemas/**
     charm-binary-python-packages:
       - jsonschema
+      - bcrypt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+bcrypt==4.2.0
 cosl==0.0.7
 ops==2.15.0
 lightkube===0.15.0

--- a/src/charm.py
+++ b/src/charm.py
@@ -1109,10 +1109,21 @@ class KratosCharm(CharmBase):
 
         identity_id = self._get_identity_id(event)
 
+        if secret_id := event.params.get("password-secret-id"):
+            try:
+                juju_secret = self.model.get_secret(id=secret_id)
+                password = juju_secret.get_content().get("password")
+            except SecretNotFoundError:
+                event.fail("Secret not found")
+                return
+            except ModelError as err:
+                event.fail(f"An error occurred: {err}")
+                return
+
         event.log("Resetting password")
 
         try:
-            if password := event.params.get("password"):
+            if secret_id:
                 ret = self.kratos.reset_password(identity_id=identity_id, password=password)
                 event.log("Password changed successfully")
             else:

--- a/src/charm.py
+++ b/src/charm.py
@@ -254,8 +254,11 @@ class KratosCharm(CharmBase):
 
         self.framework.observe(self.on.get_identity_action, self._on_get_identity_action)
         self.framework.observe(self.on.delete_identity_action, self._on_delete_identity_action)
-        # TODO: Uncomment this line after we have implemented the recovery endpoint
-        # self.framework.observe(self.on.reset_password_action, self._on_reset_password_action)
+        self.framework.observe(self.on.reset_password_action, self._on_reset_password_action)
+        self.framework.observe(
+            self.on.invalidate_identity_sessions_action, self._on_invalidate_identity_sessions_action
+        )
+        self.framework.observe(self.on.reset_identity_mfa_action, self._on_reset_identity_mfa_action)
         self.framework.observe(
             self.on.create_admin_account_action, self._on_create_admin_account_action
         )
@@ -643,7 +646,7 @@ class KratosCharm(CharmBase):
         return default_schema_id, schemas
 
     def _get_identity_schema_config(self) -> Tuple[str, Dict]:
-        """Get the the default schema id and the identity schemas.
+        """Get the default schema id and the identity schemas.
 
         The identity schemas can come from 2 different sources. We chose them in this order:
         1) If the user has defined some schemas in the juju config, return those
@@ -1063,26 +1066,31 @@ class KratosCharm(CharmBase):
         event.log("Successfully got the identity.")
         event.set_results(dict_to_action_output(identity))
 
+    def _get_identity_id(self, event: ActionEvent) -> Optional[str]:
+        identity_id = event.params.get("identity-id")
+        email = event.params.get("email")
+        if identity_id and email:
+            event.fail("Only one of identity-id and email can be provided.")
+            return None
+        elif not identity_id and not email:
+            event.fail("One of identity-id and email must be provided.")
+            return None
+
+        if email:
+            identity = self.kratos.get_identity_from_email(email)
+            if not identity:
+                event.fail("Couldn't retrieve identity_id from email.")
+                return None
+            identity_id = identity["id"]
+
+        return identity_id
+
     def _on_delete_identity_action(self, event: ActionEvent) -> None:
         if not self._kratos_service_is_running:
             event.fail("Service is not ready. Please re-run the action when the charm is active")
             return
 
-        identity_id = event.params.get("identity-id")
-        email = event.params.get("email")
-        if identity_id and email:
-            event.fail("Only one of identity-id and email can be provided.")
-            return
-        elif not identity_id and not email:
-            event.fail("One of identity-id and email must be provided.")
-            return
-
-        if email:
-            identity = self.kratos.get_identity_from_email(email)
-            identity_id = identity.get("id")
-            if not identity_id:
-                event.fail("Couldn't retrieve identity_id from email.")
-                return
+        identity_id = self._get_identity_id(event)
 
         event.log("Deleting the identity.")
         try:
@@ -1099,43 +1107,72 @@ class KratosCharm(CharmBase):
             event.fail("Service is not ready. Please re-run the action when the charm is active")
             return
 
-        identity_id = event.params.get("identity-id")
-        email = event.params.get("email")
-        recovery_method = event.params.get("recovery-method")
-        if identity_id and email:
-            event.fail("Only one of identity-id and email can be provided.")
-            return
-        elif not identity_id and not email:
-            event.fail("One of identity-id and email must be provided.")
-            return
+        identity_id = self._get_identity_id(event)
 
-        if email:
-            identity = self.kratos.get_identity_from_email(email)
-            if not identity:
-                event.fail("Couldn't retrieve identity_id from email.")
-                return
-            identity_id = identity["id"]
+        event.log("Resetting password")
 
-        if recovery_method == "code":
-            fun = self.kratos.recover_password_with_code
-        elif recovery_method == "link":
-            fun = self.kratos.recover_password_with_link
-        else:
-            event.fail(
-                f"Unsupported recovery method {recovery_method}, "
-                "allowed methods are: `code` and `link`"
-            )
-            return
-
-        event.log("Resetting password.")
         try:
-            ret = fun(identity_id=identity_id)
+            if password := event.params.get("password"):
+                ret = self.kratos.reset_password(identity_id=identity_id, password=password)
+                event.log("Password changed successfully")
+            else:
+                ret = self.kratos.recover_password_with_code(identity_id=identity_id)
+                event.log("Follow the link to reset the user's password")
         except requests.exceptions.RequestException as e:
             event.fail(f"Failed to request Kratos API: {e}")
             return
 
-        event.log("Follow the link to reset the user's password")
         event.set_results(dict_to_action_output(ret))
+
+    def _on_invalidate_identity_sessions_action(self, event: ActionEvent) -> None:
+        if not self._kratos_service_is_running:
+            event.fail("Service is not ready. Please re-run the action when the charm is active")
+            return
+
+        identity_id = self._get_identity_id(event)
+
+        event.log("Invalidating user sessions")
+        try:
+            sessions_invalidated = self.kratos.invalidate_sessions(identity_id=identity_id)
+            if not sessions_invalidated:
+                event.log("User has no sessions")
+                return
+        except requests.exceptions.RequestException as e:
+            event.fail(f"Failed to request Kratos API: {e}")
+            return
+
+        event.log("User sessions have been invalidated and deleted")
+
+    def _on_reset_identity_mfa_action(self, event: ActionEvent) -> None:
+        if not self._kratos_service_is_running:
+            event.fail("Service is not ready. Please re-run the action when the charm is active")
+            return
+
+        mfa_type = event.params.get("mfa-type")
+        identity_id = self._get_identity_id(event)
+
+        if not mfa_type:
+            event.fail("MFA type must be specified")
+            return
+
+        if mfa_type not in ("totp", "lookup_secret"):
+            event.fail(
+                f"Unsupported MFA credential type {mfa_type}, "
+                "allowed methods are: `totp` and `lookup_secret`"
+            )
+            return
+
+        event.log("Resetting user's second authentication factor")
+        try:
+            credential_deleted = self.kratos.delete_mfa_credential(identity_id=identity_id, mfa_type=mfa_type)
+            if not credential_deleted:
+                event.log(f"User has no {mfa_type} credentials")
+                return
+        except requests.exceptions.RequestException as e:
+            event.fail(f"Failed to request Kratos API: {e}")
+            return
+
+        event.log("Second authentication factor was reset")
 
     def _on_create_admin_account_action(self, event: ActionEvent) -> None:
         if not self._kratos_service_is_running:
@@ -1162,13 +1199,14 @@ class KratosCharm(CharmBase):
         res = {"identity-id": identity_id}
         event.log(f"Successfully created admin account: {identity_id}.")
         if not password:
-            event.log("Creating magic link for resetting admin password.")
+            event.log("Creating recovery code for resetting admin password.")
             try:
-                link = self.kratos.recover_password_with_link(identity_id)
+                link = self.kratos.recover_password_with_code(identity_id)
             except requests.exceptions.RequestException as e:
                 event.fail(f"Failed to request Kratos API: {e}")
                 return
             res["password-reset-link"] = link["recovery_link"]
+            res["password-reset-code"] = link["recovery_code"]
             res["expires-at"] = link["expires_at"]
 
         event.set_results(res)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -176,13 +176,19 @@ async def test_get_identity(ops_test: OpsTest) -> None:
 
 
 async def test_reset_password(ops_test: OpsTest) -> None:
+    secret_name = "password-secret"
+    secret_id = await ops_test.model.add_secret(name=secret_name, data_args=["password=some-password"])
+    await ops_test.model.grant_secret(secret_name=secret_name, application=KRATOS_APP)
+
     action = (
         await ops_test.model.applications[KRATOS_APP]
         .units[0]
         .run_action(
             "reset-password",
-            email=ADMIN_MAIL,
-            password="some-password"
+            **{
+                "email": ADMIN_MAIL,
+                "password-secret-id": secret_id,
+            },
         )
     )
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -208,19 +208,25 @@ def mocked_recover_password_with_code(
 
 
 @pytest.fixture()
-def recover_password_with_link_resp() -> Dict:
-    return {
-        "recovery_link": "http://kratos-ui/self-service/recovery?flow=e18560f9-8f50-4679-bcc9-d6cea2bb203f&token=5UJ9GgQTxvSp53zkwgOkjG9eRvnYjEYq",
-        "expires_at": "2023-04-03T21:47:52.869721347Z",
-    }
+def mocked_reset_password(mocker: MockerFixture, kratos_identity_json: Dict) -> MagicMock:
+    mock = mocker.patch(
+        "charm.KratosAPI.reset_password", return_value=kratos_identity_json
+    )
+    return mock
 
 
 @pytest.fixture()
-def mocked_recover_password_with_link(
-    mocker: MockerFixture, recover_password_with_link_resp: Dict
-) -> MagicMock:
+def mocked_invalidate_sessions(mocker: MockerFixture) -> MagicMock:
     mock = mocker.patch(
-        "charm.KratosAPI.recover_password_with_link", return_value=recover_password_with_link_resp
+        "charm.KratosAPI.invalidate_sessions", return_value=True
+    )
+    return mock
+
+
+@pytest.fixture()
+def mocked_delete_mfa_credential(mocker: MockerFixture) -> MagicMock:
+    mock = mocker.patch(
+        "charm.KratosAPI.delete_mfa_credential", return_value=True
     )
     return mock
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1223,6 +1223,8 @@ def test_on_config_changed_when_missing_login_ui_and_hydra_relation_data(
         "_on_reset_password_action",
         "_on_create_admin_account_action",
         "_on_run_migration_action",
+        "_on_invalidate_identity_sessions_action",
+        "_on_reset_identity_mfa_action",
     ],
 )
 def test_actions_when_cannot_connect(harness: Harness, action: str) -> None:
@@ -1365,6 +1367,62 @@ def test_error_on_delete_identity_action_with_email(
     event.fail.assert_called()
 
 
+def test_reset_password_action_when_password_provided_with_identity_id(
+    harness: Harness,
+    mocked_kratos_service: MagicMock,
+    mocked_reset_password: MagicMock,
+) -> None:
+    event = MagicMock()
+    event.params = {"identity-id": "123", "password": "new-password"}
+
+    harness.charm._on_reset_password_action(event)
+
+    event.set_results.assert_called()
+
+
+def test_error_on_reset_password_action_when_password_provided_with_identity_id(
+    harness: Harness,
+    mocked_kratos_service: MagicMock,
+    mocked_reset_password: MagicMock,
+) -> None:
+    mocked_reset_password.side_effect = requests.exceptions.HTTPError()
+    event = MagicMock()
+    event.params = {"identity-id": "123", "password": "new-password"}
+
+    harness.charm._on_reset_password_action(event)
+
+    event.fail.assert_called()
+
+
+def test_reset_password_action_when_password_provided_with_email(
+    harness: Harness,
+    mocked_kratos_service: MagicMock,
+    mocked_get_identity_from_email: MagicMock,
+    mocked_reset_password: MagicMock,
+) -> None:
+    event = MagicMock()
+    event.params = {"email": "test@example.com", "password": "new-password"}
+
+    harness.charm._on_reset_password_action(event)
+
+    event.set_results.assert_called()
+
+
+def test_error_on_reset_password_action_when_password_provided_with_email(
+    harness: Harness,
+    mocked_kratos_service: MagicMock,
+    mocked_get_identity_from_email: MagicMock,
+    mocked_reset_password: MagicMock,
+) -> None:
+    mocked_reset_password.side_effect = requests.exceptions.HTTPError()
+    event = MagicMock()
+    event.params = {"email": "test@example.com", "password": "new-password"}
+
+    harness.charm._on_reset_password_action(event)
+
+    event.fail.assert_called()
+
+
 def test_reset_password_action_with_code_with_identity_id(
     harness: Harness,
     mocked_kratos_service: MagicMock,
@@ -1372,7 +1430,7 @@ def test_reset_password_action_with_code_with_identity_id(
 ) -> None:
     identity_id = mocked_recover_password_with_code.return_value
     event = MagicMock()
-    event.params = {"identity-id": identity_id, "recovery-method": "code"}
+    event.params = {"identity-id": identity_id}
 
     harness.charm._on_reset_password_action(event)
 
@@ -1386,7 +1444,7 @@ def test_error_on_reset_password_action_with_code_with_identity_id(
 ) -> None:
     mocked_recover_password_with_code.side_effect = requests.exceptions.HTTPError()
     event = MagicMock()
-    event.params = {"identity-id": "identity_id", "recovery-method": "code"}
+    event.params = {"identity-id": "identity_id"}
 
     harness.charm._on_reset_password_action(event)
 
@@ -1401,67 +1459,176 @@ def test_reset_password_action_with_code_with_email(
 ) -> None:
     identity_id = mocked_recover_password_with_code.return_value
     event = MagicMock()
-    event.params = {"identity-id": identity_id, "recovery-method": "code"}
+    event.params = {"identity-id": identity_id}
 
     harness.charm._on_reset_password_action(event)
 
     event.set_results.assert_called()
 
 
-def test_reset_password_action_with_link_with_identity_id(
+def test_error_on_reset_mfa_action_with_identity_id_when_mfa_type_not_provided(
     harness: Harness,
     mocked_kratos_service: MagicMock,
-    mocked_recover_password_with_link: MagicMock,
+    mocked_delete_mfa_credential: MagicMock,
 ) -> None:
-    identity_id = mocked_recover_password_with_link.return_value
     event = MagicMock()
-    event.params = {"identity-id": identity_id, "recovery-method": "link"}
+    event.params = {"identity-id": "123"}
 
-    harness.charm._on_reset_password_action(event)
+    harness.charm._on_reset_identity_mfa_action(event)
 
-    event.set_results.assert_called()
+    event.fail.assert_called_with("MFA type must be specified")
 
 
-def test_error_on_reset_password_action_with_link_with_identity_id(
+def test_error_on_reset_mfa_action_with_identity_id_when_mfa_type_uncorrect(
     harness: Harness,
     mocked_kratos_service: MagicMock,
-    mocked_recover_password_with_link: MagicMock,
+    mocked_delete_mfa_credential: MagicMock,
 ) -> None:
-    mocked_recover_password_with_link.side_effect = requests.exceptions.HTTPError()
     event = MagicMock()
-    event.params = {"identity-id": "identity_id", "recovery-method": "link"}
+    unsupported_type = "test"
+    event.params = {"identity-id": "123", "mfa-type": unsupported_type}
 
-    harness.charm._on_reset_password_action(event)
+    harness.charm._on_reset_identity_mfa_action(event)
+
+    event.fail.assert_called_with(f"Unsupported MFA credential type {unsupported_type}, allowed methods are: `totp` and `lookup_secret`")
+
+
+@pytest.mark.parametrize("mfa_type", ["totp", "lookup_secret"])
+def test_reset_mfa_action_with_identity_id(
+    harness: Harness,
+    mocked_kratos_service: MagicMock,
+    mocked_delete_mfa_credential: MagicMock,
+    mfa_type: str,
+) -> None:
+    params = {"identity-id": "123", "mfa-type": mfa_type}
+
+    action_output = harness.run_action("reset-identity-mfa", params)
+
+    assert "Second authentication factor was reset" in action_output.logs
+
+
+@pytest.mark.parametrize("mfa_type", ["totp", "lookup_secret"])
+def test_reset_mfa_action_with_email(
+    harness: Harness,
+    mocked_kratos_service: MagicMock,
+    mocked_get_identity_from_email: MagicMock,
+    mocked_delete_mfa_credential: MagicMock,
+    mfa_type: str,
+) -> None:
+    params = {"email": "test@example.com", "mfa-type": mfa_type}
+
+    action_output = harness.run_action("reset-identity-mfa", params)
+
+    assert "Second authentication factor was reset" in action_output.logs
+
+
+@pytest.mark.parametrize("mfa_type", ["totp", "lookup_secret"])
+def test_reset_mfa_action_with_identity_id_when_no_credentials(
+    harness: Harness,
+    mocked_kratos_service: MagicMock,
+    mocked_delete_mfa_credential: MagicMock,
+    mfa_type: str,
+) -> None:
+    mocked_delete_mfa_credential.return_value = False
+    params = {"identity-id": "123", "mfa-type": mfa_type}
+
+    action_output = harness.run_action("reset-identity-mfa", params)
+
+    assert f"User has no {mfa_type} credentials" in action_output.logs
+
+
+@pytest.mark.parametrize("mfa_type", ["totp", "lookup_secret"])
+def test_reset_mfa_action_with_email_when_no_credentials(
+    harness: Harness,
+    mocked_kratos_service: MagicMock,
+    mocked_get_identity_from_email: MagicMock,
+    mocked_delete_mfa_credential: MagicMock,
+    mfa_type: str,
+) -> None:
+    mocked_delete_mfa_credential.return_value = False
+    params = {"email": "test@example.com", "mfa-type": mfa_type}
+
+    action_output = harness.run_action("reset-identity-mfa", params)
+
+    assert f"User has no {mfa_type} credentials" in action_output.logs
+
+
+def test_error_on_reset_mfa_action_with_identity_id(
+    harness: Harness,
+    mocked_kratos_service: MagicMock,
+    mocked_delete_mfa_credential: MagicMock,
+) -> None:
+    event = MagicMock()
+    mocked_delete_mfa_credential.side_effect = requests.exceptions.HTTPError()
+    event.params = {"identity-id": "123"}
+
+    harness.charm._on_reset_identity_mfa_action(event)
 
     event.fail.assert_called()
 
 
-def test_reset_password_action_with_link_with_email(
+def test_invalidate_sessions_action_with_identity_id(
+    harness: Harness,
+    mocked_kratos_service: MagicMock,
+    mocked_invalidate_sessions: MagicMock,
+) -> None:
+    params = {"identity-id": "123"}
+
+    action_output = harness.run_action("invalidate-identity-sessions", params)
+
+    assert "User sessions have been invalidated and deleted" in action_output.logs
+
+
+def test_invalidate_sessions_action_with_email(
     harness: Harness,
     mocked_kratos_service: MagicMock,
     mocked_get_identity_from_email: MagicMock,
-    mocked_recover_password_with_link: MagicMock,
+    mocked_invalidate_sessions: MagicMock,
 ) -> None:
-    identity_id = mocked_recover_password_with_link.return_value
-    event = MagicMock()
-    event.params = {"identity-id": identity_id, "recovery-method": "link"}
+    params = {"email": "test@example.com"}
 
-    harness.charm._on_reset_password_action(event)
+    action_output = harness.run_action("invalidate-identity-sessions", params)
 
-    event.set_results.assert_called()
+    assert "User sessions have been invalidated and deleted" in action_output.logs
 
 
-def test_error_on_reset_password_action_with_link_with_email(
+def test_invalidate_sessions_action_with_identity_id_when_no_sessions(
+    harness: Harness,
+    mocked_kratos_service: MagicMock,
+    mocked_invalidate_sessions: MagicMock,
+) -> None:
+    mocked_invalidate_sessions.return_value = False
+    params = {"identity-id": "123"}
+
+    action_output = harness.run_action("invalidate-identity-sessions", params)
+
+    assert "User has no sessions" in action_output.logs
+
+
+def test_invalidate_sessions_action_with_email_when_no_sessions(
     harness: Harness,
     mocked_kratos_service: MagicMock,
     mocked_get_identity_from_email: MagicMock,
-    mocked_recover_password_with_link: MagicMock,
+    mocked_invalidate_sessions: MagicMock,
 ) -> None:
-    mocked_recover_password_with_link.side_effect = requests.exceptions.HTTPError()
-    event = MagicMock()
-    event.params = {"identity-id": "identity_id", "recovery-method": "link"}
+    mocked_invalidate_sessions.return_value = False
+    params = {"email": "test@example.com"}
 
-    harness.charm._on_reset_password_action(event)
+    action_output = harness.run_action("invalidate-identity-sessions", params)
+
+    assert "User has no sessions" in action_output.logs
+
+
+def test_error_on_invalidate_sessions_action_with_identity_id(
+    harness: Harness,
+    mocked_kratos_service: MagicMock,
+    mocked_invalidate_sessions: MagicMock,
+) -> None:
+    event = MagicMock()
+    mocked_invalidate_sessions.side_effect = requests.exceptions.HTTPError()
+    event.params = {"identity-id": "123"}
+
+    harness.charm._on_invalidate_identity_sessions_action(event)
 
     event.fail.assert_called()
 
@@ -1482,7 +1649,7 @@ def test_create_admin_account_without_password(
     harness: Harness,
     mocked_kratos_service: MagicMock,
     mocked_create_identity: MagicMock,
-    mocked_recover_password_with_link: MagicMock,
+    mocked_recover_password_with_code: MagicMock,
 ) -> None:
     event = MagicMock()
     event.params = {"username": "username"}
@@ -1491,8 +1658,9 @@ def test_create_admin_account_without_password(
 
     event.set_results.assert_called_with({
         "identity-id": mocked_create_identity.return_value["id"],
-        "password-reset-link": mocked_recover_password_with_link.return_value["recovery_link"],
-        "expires-at": mocked_recover_password_with_link.return_value["expires_at"],
+        "password-reset-link": mocked_recover_password_with_code.return_value["recovery_link"],
+        "password-reset-code": mocked_recover_password_with_code.return_value["recovery_code"],
+        "expires-at": mocked_recover_password_with_code.return_value["expires_at"],
     })
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1367,60 +1367,89 @@ def test_error_on_delete_identity_action_with_email(
     event.fail.assert_called()
 
 
-def test_reset_password_action_when_password_provided_with_identity_id(
+def test_reset_password_action_when_password_secret_id_provided_with_identity_id(
     harness: Harness,
     mocked_kratos_service: MagicMock,
     mocked_reset_password: MagicMock,
 ) -> None:
+    secret_content = {"password": "some-password"}
+    secret_id = harness.add_user_secret(secret_content)
+    harness.grant_secret(secret_id, "kratos")
+
     event = MagicMock()
-    event.params = {"identity-id": "123", "password": "new-password"}
+    event.params = {"identity-id": "123", "password-secret-id": secret_id}
 
     harness.charm._on_reset_password_action(event)
 
     event.set_results.assert_called()
 
 
-def test_error_on_reset_password_action_when_password_provided_with_identity_id(
+def test_error_on_reset_password_action_when_password_secret_id_provided_with_identity_id(
     harness: Harness,
     mocked_kratos_service: MagicMock,
     mocked_reset_password: MagicMock,
 ) -> None:
-    mocked_reset_password.side_effect = requests.exceptions.HTTPError()
+    secret_content = {"password": "some-password"}
+    secret_id = harness.add_user_secret(secret_content)
+    harness.grant_secret(secret_id, "kratos")
+
+    mocked_reset_password.side_effect = requests.exceptions.HTTPError("error")
     event = MagicMock()
-    event.params = {"identity-id": "123", "password": "new-password"}
+    event.params = {"identity-id": "123", "password-secret-id": secret_id}
 
     harness.charm._on_reset_password_action(event)
 
-    event.fail.assert_called()
+    event.fail.assert_called_with("Failed to request Kratos API: error")
 
 
-def test_reset_password_action_when_password_provided_with_email(
+def test_reset_password_action_when_password_secret_id_invalid_with_identity_id(
+    harness: Harness,
+    mocked_kratos_service: MagicMock,
+    mocked_reset_password: MagicMock,
+) -> None:
+    event = MagicMock()
+    event.params = {"identity-id": "123", "password-secret-id": "invalid-juju-secret-id"}
+
+    harness.charm._on_reset_password_action(event)
+
+    event.fail.assert_called_with("Secret not found")
+
+
+def test_reset_password_action_when_password_secret_id_provided_with_email(
     harness: Harness,
     mocked_kratos_service: MagicMock,
     mocked_get_identity_from_email: MagicMock,
     mocked_reset_password: MagicMock,
 ) -> None:
+    secret_content = {"password": "some-password"}
+    secret_id = harness.add_user_secret(secret_content)
+    harness.grant_secret(secret_id, "kratos")
+
     event = MagicMock()
-    event.params = {"email": "test@example.com", "password": "new-password"}
+    event.params = {"email": "test@example.com", "password-secret-id": secret_id}
 
     harness.charm._on_reset_password_action(event)
 
     event.set_results.assert_called()
 
 
-def test_error_on_reset_password_action_when_password_provided_with_email(
+def test_error_on_reset_password_action_when_password_secret_id_provided_with_email(
     harness: Harness,
     mocked_kratos_service: MagicMock,
     mocked_get_identity_from_email: MagicMock,
     mocked_reset_password: MagicMock,
 ) -> None:
-    mocked_reset_password.side_effect = requests.exceptions.HTTPError()
+    secret_content = {"password": "some-password"}
+    secret_id = harness.add_user_secret(secret_content)
+    harness.grant_secret(secret_id, "kratos")
+
+    mocked_reset_password.side_effect = requests.exceptions.HTTPError("error")
     event = MagicMock()
-    event.params = {"email": "test@example.com", "password": "new-password"}
+    event.params = {"email": "test@example.com", "password-secret-id": secret_id}
 
     harness.charm._on_reset_password_action(event)
 
-    event.fail.assert_called()
+    event.fail.assert_called_with("Failed to request Kratos API: error")
 
 
 def test_reset_password_action_with_code_with_identity_id(

--- a/tests/unit/test_kratos.py
+++ b/tests/unit/test_kratos.py
@@ -195,16 +195,36 @@ def test_recover_password_with_code(
     assert ret == recover_password_with_code_resp
 
 
-def test_recover_password_with_link(
-    kratos_api: KratosAPI, mocker: MockerFixture, recover_password_with_link_resp: Dict
+def test_reset_password(
+    kratos_api: KratosAPI, mocker: MockerFixture, kratos_identity_json: Dict
 ) -> None:
     mocked_resp = MagicMock()
-    mocked_resp.json.return_value = recover_password_with_link_resp
-    mocker.patch("requests.post", return_value=mocked_resp)
+    mocked_resp.json.return_value = kratos_identity_json
+    mocker.patch("requests.put", return_value=mocked_resp)
 
-    ret = kratos_api.recover_password_with_link("identity_id")
+    ret = kratos_api.reset_password("identity_id", "password")
 
-    assert ret == recover_password_with_link_resp
+    assert ret == kratos_identity_json
+
+
+def test_invalidate_sessions(
+    kratos_api: KratosAPI, mocker: MockerFixture
+) -> None:
+    mocker.patch("requests.delete")
+
+    ret = kratos_api.invalidate_sessions("identity_id")
+
+    assert ret
+
+
+def test_delete_mfa_credential(
+    kratos_api: KratosAPI, mocker: MockerFixture
+) -> None:
+    mocker.patch("requests.delete")
+
+    ret = kratos_api.delete_mfa_credential("identity_id", "totp")
+
+    assert ret
 
 
 def test_run_migration(kratos_api: KratosAPI, mocked_kratos_process: MagicMock) -> None:


### PR DESCRIPTION
This PR adds juju actions for sessions invalidation, password reset (with either recovery code or a password hashed with the default bcrypt algorithm) and mfa credentials reset.
It removes password reset with link method because it is [considered deprecated](https://www.ory.sh/docs/kratos/self-service/flows/account-recovery-password-reset#comparison).

Password will still be required for admin account creation because the credentials must be provided in `kratos import identities`.