### PR TITLE
feat: support local identity provider

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -103,6 +103,15 @@ config:
         Run Kratos on dev mode, it is needed if HTTPS is not set up. This should only be used for development purposes.
       type: boolean
       default: False
+    enable_local_idp:
+      description: Enable Kratos Identity Provider
+      type: boolean
+      default: True
+    enable_passwordless_login_method:
+      description: |
+        Enable passwordless authentication via webauthn. Requires `enable_local_idp=True`.
+      type: boolean
+      default: False
     identity_schemas:
       description: |
         A mapping of schema_id to identity schemas. For example:

--- a/identity_schemas/admin_v0.json
+++ b/identity_schemas/admin_v0.json
@@ -24,10 +24,24 @@
           "title": "E-Mail",
           "minLength": 3,
           "ory.sh/kratos": {
-            "verification": {
-              "via": "email"
+              "credentials": {
+                "password": {
+                  "identifier": true
+                },
+                "totp": {
+                   "account_name": true
+                },
+                "webauthn": {
+                  "identifier": true
+                }
+              },
+              "verification": {
+                "via": "email"
+              },
+              "recovery": {
+                "via": "email"
+              }
             }
-          }
         },
         "name": {
           "type": "string",

--- a/identity_schemas/social_user_v0.json
+++ b/identity_schemas/social_user_v0.json
@@ -50,7 +50,27 @@
         "email": {
           "type": "string",
           "format": "email",
-          "title": "E-Mail"
+          "title": "E-Mail",
+          "minLength": 3,
+            "ory.sh/kratos": {
+              "credentials": {
+                "password": {
+                  "identifier": true
+                },
+                "totp": {
+                   "account_name": true
+                },
+                "webauthn": {
+                  "identifier": true
+                }
+              },
+              "verification": {
+                "via": "email"
+              },
+              "recovery": {
+                "via": "email"
+              }
+            }
         },
         "gender": {
           "type": "string",

--- a/lib/charms/identity_platform_login_ui_operator/v0/login_ui_endpoints.py
+++ b/lib/charms/identity_platform_login_ui_operator/v0/login_ui_endpoints.py
@@ -52,7 +52,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 6
 
 RELATION_NAME = "ui-endpoint-info"
 INTERFACE_NAME = "login_ui_endpoints"
@@ -63,6 +63,10 @@ RELATION_KEYS = [
     "error_url",
     "login_url",
     "oidc_error_url",
+    "device_verification_url",
+    "post_device_done_url",
+    "recovery_url",
+    "settings_url",
 ]
 
 
@@ -110,6 +114,10 @@ class LoginUIEndpointsProvider(Object):
                 "error_url": f"{endpoint}/ui/error",
                 "login_url": f"{endpoint}/ui/login",
                 "oidc_error_url": f"{endpoint}/ui/oidc_error",
+                "device_verification_url": f"{endpoint}/ui/device_code",
+                "post_device_done_url": f"{endpoint}/ui/device_complete",
+                "recovery_url": f"{endpoint}/ui/reset_email",
+                "settings_url": f"{endpoint}/ui/reset_password",
             }
         for relation in relations:
             relation.data[self._charm.app].update(endpoint_databag)

--- a/src/charm.py
+++ b/src/charm.py
@@ -516,15 +516,17 @@ class KratosCharm(CharmBase):
         login_ui_url = self._get_login_ui_endpoint_info("login_url")
         mappers = self._get_claims_mappers()
         cookie_secrets = self._get_secret()
+        parsed_public_url = urlparse(self._public_url)
 
         allowed_return_urls = []
+        origin = ""
         if self._public_url:
             allowed_return_urls = [
-                urlparse(self._public_url)
-                ._replace(path="", params="", query="", fragment="")
+                parsed_public_url._replace(path="", params="", query="", fragment="")
                 .geturl()
                 + "/"
             ]
+            origin = f"{parsed_public_url.scheme}://{parsed_public_url.hostname}"
 
         rendered = template.render(
             cookie_secrets=[cookie_secrets] if cookie_secrets else None,
@@ -536,10 +538,16 @@ class KratosCharm(CharmBase):
             default_identity_schema_id=default_schema_id,
             login_ui_url=login_ui_url,
             error_ui_url=self._get_login_ui_endpoint_info("error_url"),
+            settings_ui_url=self._get_login_ui_endpoint_info("settings_url"),
+            recovery_ui_url=self._get_login_ui_endpoint_info("recovery_url"),
             oidc_providers=oidc_providers,
             available_mappers=self._get_available_mappers,
             oauth2_provider_url=self._get_hydra_endpoint_info(),
             smtp_connection_uri=self.config.get("smtp_connection_uri"),
+            enable_local_idp=self.config.get("enable_local_idp"),
+            enable_passwordless_login_method=self.config.get("enable_passwordless_login_method"),
+            origin=origin,
+            domain=parsed_public_url.hostname,
         )
         return rendered
 

--- a/templates/kratos.yaml.j2
+++ b/templates/kratos.yaml.j2
@@ -27,6 +27,21 @@ selfservice:
         login:
             ui_url: {{ login_ui_url }}
         {%- endif %}
+        {%- if settings_ui_url %}
+        settings:
+            ui_url: {{ settings_ui_url }}
+            required_aal: highest_available
+        {%- endif %}
+        {%- if recovery_ui_url %}
+        recovery:
+            enabled: True
+            ui_url: {{ recovery_ui_url }}
+            use: code
+            after:
+                default_browser_return_url: {{ default_browser_return_url }}
+                hooks:
+                    - hook: revoke_active_sessions
+        {%- endif %}
         {%- if oidc_providers %}
         registration:
             after:
@@ -35,10 +50,38 @@ selfservice:
                     - hook: session
         {%- endif %}
     {%- endif %}
-    {%- if oidc_providers %}
+    {%- if oidc_providers or recovery_ui_url or enable_local_idp and login_ui_url %}
     methods:
+        {%- if recovery_ui_url %}
+        code:
+            enabled: True
+        {%- endif %}
+        {%- if not enable_local_idp or not login_ui_url %}
         password:
-            enabled: false
+            enabled: False
+        {%- endif %}
+        {%- if enable_local_idp and login_ui_url %}
+        password:
+            enabled: True
+            config:
+                haveibeenpwned_enabled: False
+        totp:
+            enabled: True
+            config:
+                issuer: Identity Platform
+        {%- if enable_passwordless_login_method %}
+        webauthn:
+            enabled: True
+            config:
+                passwordless: True
+                rp:
+                    id: {{ domain }}
+                    origins:
+                        - {{ origin }}
+                    display_name: Identity Platform
+        {%- endif %}
+        {%- endif %}
+        {%- if oidc_providers %}
         oidc:
             config:
                 providers:
@@ -52,6 +95,7 @@ selfservice:
                       {%- endif %}
                 {%- endfor %}
             enabled: True
+        {%- endif %}
     {%- endif %}
 {%- if cookie_secrets %}
 secrets:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -115,6 +115,10 @@ def setup_login_ui_relation(harness: Harness) -> tuple[int, dict]:
         "error_url": f"{endpoint}/ui/error",
         "login_url": f"{endpoint}/ui/login",
         "oidc_error_url": f"{endpoint}/ui/oidc_error",
+        "device_verification_url": f"{endpoint}/ui/device_code",
+        "post_device_done_url": f"{endpoint}/ui/device_complete",
+        "settings_url": f"{endpoint}/ui/settings",
+        "recovery_url": f"{endpoint}/ui/recovery",
     }
     harness.update_relation_data(
         relation_id,
@@ -231,11 +235,13 @@ def validate_config(
         assert all(schema in schemas for schema in expected_schemas)
 
     if not validate_mappers and "methods" in config["selfservice"]:
-        for p in config["selfservice"]["methods"]["oidc"]["config"]["providers"]:
-            p.pop("mapper_url")
+        if "oidc" in config["selfservice"]["methods"]:
+            for p in config["selfservice"]["methods"]["oidc"]["config"]["providers"]:
+                p.pop("mapper_url")
     if not validate_mappers and "methods" in config["selfservice"]:
-        for p in expected_config["selfservice"]["methods"]["oidc"]["config"]["providers"]:
-            p.pop("mapper_url")
+        if "oidc" in config["selfservice"]["methods"]:
+            for p in expected_config["selfservice"]["methods"]["oidc"]["config"]["providers"]:
+                p.pop("mapper_url")
 
     assert config == expected_config
 
@@ -379,6 +385,40 @@ def test_on_pebble_ready_has_correct_config_when_database_is_created(
                 },
                 "login": {
                     "ui_url": login_databag["login_url"],
+                },
+                "settings": {
+                    "ui_url": login_databag["settings_url"],
+                    "required_aal": "highest_available",
+                },
+                "recovery": {
+                    "enabled": True,
+                    "ui_url": login_databag["recovery_url"],
+                    "use": "code",
+                    "after": {
+                        "default_browser_return_url": login_databag["login_url"],
+                        "hooks": [
+                            {
+                                "hook": "revoke_active_sessions",
+                            },
+                        ],
+                    },
+                },
+            },
+            "methods": {
+                "code": {
+                    "enabled": True,
+                },
+                "password": {
+                    "enabled": True,
+                    "config": {
+                        "haveibeenpwned_enabled": False,
+                    },
+                },
+                "totp": {
+                    "enabled": True,
+                    "config": {
+                        "issuer": "Identity Platform",
+                    },
                 },
             },
         },
@@ -770,6 +810,23 @@ def test_on_client_config_changed_with_ingress(
                 "login": {
                     "ui_url": login_databag["login_url"],
                 },
+                "settings": {
+                    "ui_url": login_databag["settings_url"],
+                    "required_aal": "highest_available",
+                },
+                "recovery": {
+                    "enabled": True,
+                    "ui_url": login_databag["recovery_url"],
+                    "use": "code",
+                    "after": {
+                        "default_browser_return_url": login_databag["login_url"],
+                        "hooks": [
+                                {
+                                    "hook": "revoke_active_sessions",
+                                },
+                            ],
+                    },
+                },
                 "registration": {
                     "after": {
                         "oidc": {
@@ -783,8 +840,20 @@ def test_on_client_config_changed_with_ingress(
                 },
             },
             "methods": {
+                "code": {
+                    "enabled": True,
+                },
                 "password": {
-                    "enabled": False,
+                    "enabled": True,
+                        "config": {
+                            "haveibeenpwned_enabled": False,
+                        },
+                    },
+                    "totp": {
+                        "enabled": True,
+                        "config": {
+                            "issuer": "Identity Platform",
+                        },
                 },
                 "oidc": {
                     "config": {
@@ -875,6 +944,40 @@ def test_on_client_config_relation_removed_with_ingress(
                 "login": {
                     "ui_url": login_databag["login_url"],
                 },
+                "settings": {
+                    "ui_url": login_databag["settings_url"],
+                    "required_aal": "highest_available",
+                },
+                "recovery": {
+                    "enabled": True,
+                    "ui_url": login_databag["recovery_url"],
+                    "use": "code",
+                    "after": {
+                        "default_browser_return_url": login_databag["login_url"],
+                        "hooks": [
+                            {
+                                "hook": "revoke_active_sessions",
+                            },
+                        ],
+                    },
+                },
+            },
+            "methods": {
+                "code": {
+                    "enabled": True,
+                },
+                "password": {
+                    "enabled": True,
+                    "config": {
+                        "haveibeenpwned_enabled": False,
+                    },
+                },
+                "totp": {
+                    "enabled": True,
+                    "config": {
+                        "issuer": "Identity Platform",
+                    },
+                },
             },
         },
         "courier": {
@@ -940,6 +1043,40 @@ def test_on_client_config_data_removed_with_ingress(
                 "login": {
                     "ui_url": login_databag["login_url"],
                 },
+                "settings": {
+                    "ui_url": login_databag["settings_url"],
+                    "required_aal": "highest_available",
+                },
+                "recovery": {
+                    "enabled": True,
+                    "ui_url": login_databag["recovery_url"],
+                    "use": "code",
+                    "after": {
+                        "default_browser_return_url": login_databag["login_url"],
+                        "hooks": [
+                            {
+                                "hook": "revoke_active_sessions",
+                            },
+                        ],
+                    },
+                },
+            },
+            "methods": {
+                "code": {
+                    "enabled": True,
+                },
+                "password": {
+                    "enabled": True,
+                    "config": {
+                        "haveibeenpwned_enabled": False,
+                    },
+                },
+                "totp": {
+                    "enabled": True,
+                    "config": {
+                        "issuer": "Identity Platform",
+                    },
+                },
             },
         },
         "courier": {
@@ -999,6 +1136,40 @@ def test_on_config_changed_with_hydra(
                 },
                 "login": {
                     "ui_url": login_databag["login_url"],
+                },
+                "settings": {
+                    "ui_url": login_databag["settings_url"],
+                    "required_aal": "highest_available",
+                },
+                "recovery": {
+                    "enabled": True,
+                    "ui_url": login_databag["recovery_url"],
+                    "use": "code",
+                    "after": {
+                        "default_browser_return_url": login_databag["login_url"],
+                        "hooks": [
+                            {
+                                "hook": "revoke_active_sessions",
+                            },
+                        ],
+                    },
+                },
+            },
+            "methods": {
+                "code": {
+                    "enabled": True,
+                },
+                "password": {
+                    "enabled": True,
+                    "config": {
+                        "haveibeenpwned_enabled": False,
+                    },
+                },
+                "totp": {
+                    "enabled": True,
+                    "config": {
+                        "issuer": "Identity Platform",
+                    },
                 },
             },
         },
@@ -1061,6 +1232,40 @@ def test_on_config_changed_when_missing_hydra_relation_data(
                 },
                 "login": {
                     "ui_url": login_databag["login_url"],
+                },
+                "settings": {
+                    "ui_url": login_databag["settings_url"],
+                    "required_aal": "highest_available",
+                },
+                "recovery": {
+                    "enabled": True,
+                    "ui_url": login_databag["recovery_url"],
+                    "use": "code",
+                    "after": {
+                        "default_browser_return_url": login_databag["login_url"],
+                        "hooks": [
+                            {
+                                "hook": "revoke_active_sessions",
+                            },
+                        ],
+                    },
+                },
+            },
+            "methods": {
+                "code": {
+                    "enabled": True,
+                },
+                "password": {
+                    "enabled": True,
+                    "config": {
+                        "haveibeenpwned_enabled": False,
+                    },
+                },
+                "totp": {
+                    "enabled": True,
+                    "config": {
+                        "issuer": "Identity Platform",
+                    },
                 },
             },
         },
@@ -1139,7 +1344,9 @@ def test_on_changed_without_login_ui_endpoints(
                 },
             ],
         },
-        "selfservice": {"default_browser_return_url": DEFAULT_BROWSER_RETURN_URL},
+        "selfservice": {
+            "default_browser_return_url": DEFAULT_BROWSER_RETURN_URL,
+        },
         "courier": {
             "smtp": {"connection_uri": "smtps://test:test@mailslurper:1025/?skip_ssl_verify=true"}
         },
@@ -1195,7 +1402,9 @@ def test_on_config_changed_when_missing_login_ui_and_hydra_relation_data(
                 },
             ],
         },
-        "selfservice": {"default_browser_return_url": DEFAULT_BROWSER_RETURN_URL},
+        "selfservice": {
+            "default_browser_return_url": DEFAULT_BROWSER_RETURN_URL,
+        },
         "courier": {
             "smtp": {"connection_uri": "smtps://test:test@mailslurper:1025/?skip_ssl_verify=true"}
         },
@@ -1205,6 +1414,208 @@ def test_on_config_changed_when_missing_login_ui_and_hydra_relation_data(
                     "enabled": True,
                 },
             },
+        },
+    }
+
+    configmap = mocked_kratos_configmap.update.call_args_list[-1][0][0]
+    config = configmap["kratos.yaml"]
+    validate_config(
+        expected_config, yaml.safe_load(config), validate_schemas=False, validate_mappers=False
+    )
+
+
+def test_on_config_changed_when_local_idp_disabled(
+    harness: Harness,
+    mocked_kratos_configmap: MagicMock,
+    mocked_migration_is_needed: MagicMock
+) -> None:
+    setup_peer_relation(harness)
+    setup_postgres_relation(harness)
+    (_, login_databag) = setup_login_ui_relation(harness)
+
+    container = harness.model.unit.get_container(CONTAINER_NAME)
+    harness.charm.on.leader_elected.emit()
+    harness.charm.on.kratos_pebble_ready.emit(container)
+    setup_hydra_relation(harness)
+
+    harness.update_config({"enable_local_idp": False})
+
+    expected_config = {
+        "log": {
+            "level": "info",
+            "format": "json",
+        },
+        "identity": {
+            "default_schema_id": "social_user_v0",
+            "schemas": [
+                {"id": "admin_v0", "url": "base64://something"},
+                {
+                    "id": "social_user_v0",
+                    "url": "base64://something",
+                },
+            ],
+        },
+        "selfservice": {
+            "default_browser_return_url": login_databag["login_url"],
+            "flows": {
+                "error": {
+                    "ui_url": login_databag["error_url"],
+                },
+                "login": {
+                    "ui_url": login_databag["login_url"],
+                },
+                "settings": {
+                    "ui_url": login_databag["settings_url"],
+                    "required_aal": "highest_available",
+                },
+                "recovery": {
+                    "enabled": True,
+                    "ui_url": login_databag["recovery_url"],
+                    "use": "code",
+                    "after": {
+                        "default_browser_return_url": login_databag["login_url"],
+                        "hooks": [
+                            {
+                                "hook": "revoke_active_sessions",
+                            },
+                        ],
+                    },
+                },
+            },
+            "methods": {
+                "code": {
+                    "enabled": True,
+                },
+                "password": {
+                    "enabled": False,
+                },
+            },
+        },
+        "courier": {
+            "smtp": {"connection_uri": "smtps://test:test@mailslurper:1025/?skip_ssl_verify=true"}
+        },
+        "serve": {
+            "public": {
+                "cors": {
+                    "enabled": True,
+                },
+            },
+        },
+        "oauth2_provider": {
+            "url": "http://hydra-admin-url:80/testing-hydra",
+        },
+    }
+
+    configmap = mocked_kratos_configmap.update.call_args_list[-1][0][0]
+    config = configmap["kratos.yaml"]
+    validate_config(
+        expected_config, yaml.safe_load(config), validate_schemas=False, validate_mappers=False
+    )
+
+
+def test_on_config_changed_when_webauthn_enabled(
+    harness: Harness,
+    mocked_kratos_configmap: MagicMock,
+    mocked_migration_is_needed: MagicMock
+) -> None:
+    setup_peer_relation(harness)
+    setup_postgres_relation(harness)
+    (_, login_databag) = setup_login_ui_relation(harness)
+    setup_ingress_relation(harness, "public")
+
+    container = harness.model.unit.get_container(CONTAINER_NAME)
+    harness.charm.on.leader_elected.emit()
+    harness.charm.on.kratos_pebble_ready.emit(container)
+    setup_hydra_relation(harness)
+
+    harness.update_config({"enable_passwordless_login_method": True})
+
+    expected_config = {
+        "log": {
+            "level": "info",
+            "format": "json",
+        },
+        "identity": {
+            "default_schema_id": "social_user_v0",
+            "schemas": [
+                {"id": "admin_v0", "url": "base64://something"},
+                {
+                    "id": "social_user_v0",
+                    "url": "base64://something",
+                },
+            ],
+        },
+        "selfservice": {
+            "allowed_return_urls": [
+                "https://public/",
+            ],
+            "default_browser_return_url": login_databag["login_url"],
+            "flows": {
+                "error": {
+                    "ui_url": login_databag["error_url"],
+                },
+                "login": {
+                    "ui_url": login_databag["login_url"],
+                },
+                "settings": {
+                    "ui_url": login_databag["settings_url"],
+                    "required_aal": "highest_available",
+                },
+                "recovery": {
+                    "enabled": True,
+                    "ui_url": login_databag["recovery_url"],
+                    "use": "code",
+                    "after": {
+                        "default_browser_return_url": login_databag["login_url"],
+                        "hooks": [
+                            {
+                                "hook": "revoke_active_sessions",
+                            },
+                        ],
+                    },
+                },
+            },
+            "methods": {
+                "code": {
+                    "enabled": True,
+                },
+                "password": {
+                    "enabled": True,
+                    "config": {
+                        "haveibeenpwned_enabled": False,
+                    },
+                },
+                "totp": {
+                    "enabled": True,
+                    "config": {
+                        "issuer": "Identity Platform",
+                    },
+                },
+                "webauthn": {
+                    "enabled": True,
+                    "config": {
+                        "passwordless": True,
+                        "rp": {
+                            "id": "public",
+                            "origins": ["https://public"],
+                            "display_name": "Identity Platform",
+                        }
+                    },
+                },
+            },
+        },
+        "courier": {
+            "smtp": {"connection_uri": "smtps://test:test@mailslurper:1025/?skip_ssl_verify=true"}
+        },
+        "serve": {
+            "public": {
+                "cors": {
+                    "enabled": True,
+                },
+            },
+        },
+        "oauth2_provider": {
+            "url": "http://hydra-admin-url:80/testing-hydra",
         },
     }
 


### PR DESCRIPTION
This PR adds support for local identity provider:
- updates identity schemas with email identifiers for the new flow methods
- adds config options to enable Kratos IdP and passwordless login method
- updates the config template
- bumps `ui-endpoint-info` lib
## Testing
1. Build kratos with `charmcraft pack`.
2. Render and deploy the identity platform bundle, replacing kratos with the locally built charm and bumping login ui revision (105 or higher).
`juju deploy ./bundle-edge.yaml --trust`
3. Deploy grafana with required relations:
```
juju deploy grafana-k8s
juju integrate grafana-k8s:ingress traefik-public
juju integrate grafana-k8s:oauth hydra
```
4. Create a user in kratos:
`juju run kratos/0 create-admin-account email=test@example.com password=test username=admin`
5. Go to https://{public-traefik-ip}/{model}-grafana-k8s to test the login flow.

To test the recovery code flow, run the `reset-password` action and go to the returned url. Self-service recovery flow doesn't work atm because there is no smtp courier, so no emails are sent. This will be addressed in the next PR.

To test MFA, log in or recover the account and go to https://{public-traefik-ip}/{model}-identity-platform-login-ui-operator/ui/setup_secure.