### PR TITLE
Add `enforce_mfa` config option

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -106,6 +106,12 @@ config:
       description: Enable Kratos Identity Provider
       type: boolean
       default: True
+    enforce_mfa:
+      description: |
+        Enforce users to set up and use multi factor authentication.
+        Disabling this option will allow users to log in with password or webauthn without completing 2fa.
+      type: boolean
+      default: True
     enable_passwordless_login_method:
       description: |
         Enable passwordless authentication via webauthn. Requires `enable_local_idp=True`.

--- a/lib/charms/kratos/v0/kratos_info.py
+++ b/lib/charms/kratos/v0/kratos_info.py
@@ -53,7 +53,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 RELATION_NAME = "kratos-info"
 INTERFACE_NAME = "kratos_info"
@@ -94,8 +94,9 @@ class KratosInfoProvider(Object):
         providers_configmap_name: str,
         schemas_configmap_name: str,
         configmaps_namespace: str,
+        mfa_enabled: bool,
     ) -> None:
-        """Updates relation with endpoints and configmaps info."""
+        """Updates relation with endpoints, config and configmaps info."""
         if not self._charm.unit.is_leader():
             return
 
@@ -108,6 +109,7 @@ class KratosInfoProvider(Object):
             "providers_configmap_name": providers_configmap_name,
             "schemas_configmap_name": schemas_configmap_name,
             "configmaps_namespace": configmaps_namespace,
+            "mfa_enabled": str(mfa_enabled),
         }
 
         for relation in relations:

--- a/src/charm.py
+++ b/src/charm.py
@@ -550,6 +550,7 @@ class KratosCharm(CharmBase):
             smtp_connection_uri=self._smtp_connection_uri,
             recovery_email_template=self._recovery_email_template,
             enable_local_idp=self.config.get("enable_local_idp"),
+            enforce_mfa=self.config.get("enforce_mfa"),
             enable_passwordless_login_method=self.config.get("enable_passwordless_login_method"),
             origin=origin,
             domain=parsed_public_url.hostname,
@@ -902,6 +903,7 @@ class KratosCharm(CharmBase):
     def _on_config_changed(self, event: ConfigChangedEvent) -> None:
         """Event Handler for config changed event."""
         self._handle_status_update_config(event)
+        self._update_kratos_info_relation_data(event)
 
     def _on_remove(self, event: RemoveEvent) -> None:
         if not self.unit.is_leader():
@@ -922,6 +924,7 @@ class KratosCharm(CharmBase):
         providers_configmap_name = self.providers_configmap.name
         schemas_configmap_name = self.schemas_configmap.name
         configmaps_namespace = self.model.name
+        mfa_enabled = self.config.get("enforce_mfa")
 
         self.info_provider.send_info_relation_data(
             admin_endpoint,
@@ -929,6 +932,7 @@ class KratosCharm(CharmBase):
             providers_configmap_name,
             schemas_configmap_name,
             configmaps_namespace,
+            mfa_enabled,
         )
 
     def _update_kratos_endpoints_relation_data(self, event: RelationEvent) -> None:

--- a/templates/kratos.yaml.j2
+++ b/templates/kratos.yaml.j2
@@ -8,6 +8,11 @@ identity:
         - id: {{ schema_id }}
           url: '{{ identity_schema }}'
         {%- endfor %}
+{%- if enable_local_idp and enforce_mfa %}
+session:
+  whoami:
+    required_aal: highest_available
+{%- endif %}
 selfservice:
     {%- if allowed_return_urls %}
     allowed_return_urls:
@@ -65,10 +70,12 @@ selfservice:
             enabled: True
             config:
                 haveibeenpwned_enabled: False
+        {%- if enforce_mfa %}
         totp:
             enabled: True
             config:
                 issuer: Identity Platform
+        {%- endif %}
         {%- if enable_passwordless_login_method %}
         webauthn:
             enabled: True

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -401,6 +401,11 @@ def test_on_pebble_ready_has_correct_config_when_database_is_created(
                 },
             ],
         },
+        "session": {
+            "whoami": {
+                "required_aal": "highest_available",
+            },
+        },
         "selfservice": {
             "default_browser_return_url": login_databag["login_url"],
             "flows": {
@@ -541,6 +546,11 @@ def test_config_file_with_smtp_integration(
                 },
             ],
         },
+        "session": {
+            "whoami": {
+                "required_aal": "highest_available",
+            },
+        },
         "selfservice": {
             "default_browser_return_url": DEFAULT_BROWSER_RETURN_URL,
         },
@@ -595,6 +605,11 @@ def test_on_config_changed_when_identity_schemas_config(
                 },
             ],
         },
+        "session": {
+            "whoami": {
+                "required_aal": "highest_available",
+            },
+        },
         "selfservice": {
             "default_browser_return_url": DEFAULT_BROWSER_RETURN_URL,
         },
@@ -648,8 +663,101 @@ def test_on_config_changed_when_identity_schemas_config_unset(
                 },
             ],
         },
+        "session": {
+            "whoami": {
+                "required_aal": "highest_available",
+            },
+        },
         "selfservice": {
             "default_browser_return_url": DEFAULT_BROWSER_RETURN_URL,
+        },
+        "courier": {
+            "smtp": {"connection_uri": "smtps://test:test@mailslurper:1025/?skip_ssl_verify=true"}
+        },
+        "serve": {
+            "public": {
+                "cors": {
+                    "enabled": True,
+                },
+            },
+        },
+    }
+
+    configmap = mocked_kratos_configmap.update.call_args_list[-1][0][0]
+    config = configmap["kratos.yaml"]
+    validate_config(
+        expected_config, yaml.safe_load(config), validate_schemas=False, validate_mappers=False
+    )
+
+
+def test_on_config_changed_when_local_idp_enabled_mfa_not_enforced(
+    harness: Harness, mocked_kratos_configmap: MagicMock, mocked_migration_is_needed: MagicMock
+) -> None:
+    setup_peer_relation(harness)
+    setup_postgres_relation(harness)
+    container = harness.model.unit.get_container(CONTAINER_NAME)
+    harness.charm.on.leader_elected.emit()
+    harness.charm.on.kratos_pebble_ready.emit(container)
+    setup_ingress_relation(harness, "public")
+    (_, login_databag) = setup_login_ui_relation(harness)
+    harness.update_config({"enforce_mfa": False})
+
+    expected_config = {
+        "log": {
+            "level": "info",
+            "format": "json",
+        },
+        "identity": {
+            "default_schema_id": "social_user_v0",
+            "schemas": [
+                {"id": "admin_v0", "url": "base64://something"},
+                {
+                    "id": "social_user_v0",
+                    "url": "base64://something",
+                },
+            ],
+        },
+        "selfservice": {
+            "allowed_return_urls": [
+                "https://public/",
+            ],
+            "default_browser_return_url": login_databag["login_url"],
+            "flows": {
+                "error": {
+                    "ui_url": login_databag["error_url"],
+                },
+                "login": {
+                    "ui_url": login_databag["login_url"],
+                },
+                "settings": {
+                    "ui_url": login_databag["settings_url"],
+                    "required_aal": "highest_available",
+                },
+                "recovery": {
+                    "enabled": True,
+                    "ui_url": login_databag["recovery_url"],
+                    "use": "code",
+                    "after": {
+                        "default_browser_return_url": login_databag["login_url"],
+                        "hooks": [
+                            {
+                                "hook": "revoke_active_sessions",
+                            },
+                        ],
+                    },
+                },
+            },
+            "methods": {
+                "code": {
+                    "enabled": True,
+                },
+                "password": {
+                    "enabled": True,
+                    "config": {
+                        "haveibeenpwned_enabled": False,
+                    },
+                },
+            },
         },
         "courier": {
             "smtp": {"connection_uri": "smtps://test:test@mailslurper:1025/?skip_ssl_verify=true"}
@@ -888,6 +996,11 @@ def test_on_client_config_changed_with_ingress(
                 },
             ],
         },
+        "session": {
+            "whoami": {
+                "required_aal": "highest_available",
+            },
+        },
         "selfservice": {
             "allowed_return_urls": [
                 "https://public/",
@@ -1022,6 +1135,11 @@ def test_on_client_config_relation_removed_with_ingress(
                 },
             ],
         },
+        "session": {
+            "whoami": {
+                "required_aal": "highest_available",
+            },
+        },
         "selfservice": {
             "allowed_return_urls": [
                 "https://public/",
@@ -1121,6 +1239,11 @@ def test_on_client_config_data_removed_with_ingress(
                 },
             ],
         },
+        "session": {
+            "whoami": {
+                "required_aal": "highest_available",
+            },
+        },
         "selfservice": {
             "allowed_return_urls": [
                 "https://public/",
@@ -1218,6 +1341,11 @@ def test_on_config_changed_with_hydra(
                 },
             ],
         },
+        "session": {
+            "whoami": {
+                "required_aal": "highest_available",
+            },
+        },
         "selfservice": {
             "default_browser_return_url": login_databag["login_url"],
             "flows": {
@@ -1313,6 +1441,11 @@ def test_on_config_changed_when_missing_hydra_relation_data(
                     "url": "base64://something",
                 },
             ],
+        },
+        "session": {
+            "whoami": {
+                "required_aal": "highest_available",
+            },
         },
         "selfservice": {
             "default_browser_return_url": login_databag["login_url"],
@@ -1434,6 +1567,11 @@ def test_on_changed_without_login_ui_endpoints(
                 },
             ],
         },
+        "session": {
+            "whoami": {
+                "required_aal": "highest_available",
+            },
+        },
         "selfservice": {
             "default_browser_return_url": DEFAULT_BROWSER_RETURN_URL,
         },
@@ -1491,6 +1629,11 @@ def test_on_config_changed_when_missing_login_ui_and_hydra_relation_data(
                     "url": "base64://something",
                 },
             ],
+        },
+        "session": {
+            "whoami": {
+                "required_aal": "highest_available",
+            },
         },
         "selfservice": {
             "default_browser_return_url": DEFAULT_BROWSER_RETURN_URL,
@@ -1652,6 +1795,11 @@ def test_on_config_changed_when_webauthn_enabled(
                     "url": "base64://something",
                 },
             ],
+        },
+        "session": {
+            "whoami": {
+                "required_aal": "highest_available",
+            },
         },
         "selfservice": {
             "allowed_return_urls": [
@@ -2325,6 +2473,7 @@ def test_kratos_info_updated_on_relation_ready(harness: Harness) -> None:
         "providers",
         "identity-schemas",
         "kratos-model",
+        True,
     )
 
 


### PR DESCRIPTION
This PR adds a config option to enable/disable MFA and updates the `kratos-info` interface to include the flag (this will be required by login-ui).