### PR TITLE
fix: use [external] ingress on login endpoint field of kratos info

### DIFF
--- a/lib/charms/kratos/v0/kratos_info.py
+++ b/lib/charms/kratos/v0/kratos_info.py
@@ -40,6 +40,7 @@ Class SomeCharm(CharmBase):
 """
 
 import logging
+from os.path import join
 from typing import Dict, Optional
 
 from ops.charm import CharmBase, RelationCreatedEvent
@@ -53,7 +54,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 RELATION_NAME = "kratos-info"
 INTERFACE_NAME = "kratos_info"
@@ -91,6 +92,7 @@ class KratosInfoProvider(Object):
         self,
         admin_endpoint: str,
         public_endpoint: str,
+        external_url: str,
         providers_configmap_name: str,
         schemas_configmap_name: str,
         configmaps_namespace: str,
@@ -100,11 +102,13 @@ class KratosInfoProvider(Object):
         if not self._charm.unit.is_leader():
             return
 
+        external_url = external_url if external_url.endswith("/") else external_url + "/"
+
         relations = self.model.relations[self._relation_name]
         info_databag = {
             "admin_endpoint": admin_endpoint,
             "public_endpoint": public_endpoint,
-            "login_browser_endpoint": f"{public_endpoint}/self-service/login/browser",
+            "login_browser_endpoint": join(external_url, "self-service/login/browser"),
             "sessions_endpoint": f"{public_endpoint}/sessions/whoami",
             "providers_configmap_name": providers_configmap_name,
             "schemas_configmap_name": schemas_configmap_name,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 author = "Canonical Ltd."
 
 [tool.ruff.lint.mccabe]
-max-complexity = 10
+max-complexity = 15 # accommodate holistic handler needs
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/src/constants.py
+++ b/src/constants.py
@@ -5,6 +5,8 @@
 
 from pathlib import Path
 
+from charms.kratos.v0.kratos_info import RELATION_NAME
+
 # Charm constants
 WORKLOAD_CONTAINER_NAME = "kratos"
 EMAIL_TEMPLATE_FILE_PATH = Path("/etc/config/templates") / "recovery-body.html.gotmpl"
@@ -31,6 +33,7 @@ CERTIFICATE_TRANSFER_RELATION_NAME = "receive-ca-cert"
 DB_RELATION_NAME = "pg-database"
 HYDRA_RELATION_NAME = "hydra-endpoint-info"
 LOGIN_UI_RELATION_NAME = "ui-endpoint-info"
+KRATOS_INFO_RELATION_NAME = RELATION_NAME
 PROMETHEUS_SCRAPE_RELATION_NAME = "metrics-endpoint"
 LOKI_PUSH_API_RELATION_NAME = "logging"
 GRAFANA_DASHBOARD_RELATION_NAME = "grafana-dashboard"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -89,12 +89,14 @@ async def test_ingress_relation(ops_test: OpsTest) -> None:
     await ops_test.model.deploy(
         TRAEFIK_CHARM,
         application_name=TRAEFIK_PUBLIC_APP,
+        trust=True,
         channel="latest/edge",
         config={"external_hostname": "some_hostname"},
     )
     await ops_test.model.deploy(
         TRAEFIK_CHARM,
         application_name=TRAEFIK_ADMIN_APP,
+        trust=True,
         channel="latest/edge",
         config={"external_hostname": "some_hostname"},
     )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -90,14 +90,14 @@ async def test_ingress_relation(ops_test: OpsTest) -> None:
         TRAEFIK_CHARM,
         application_name=TRAEFIK_PUBLIC_APP,
         trust=True,
-        channel="latest/edge",
+        channel="latest/stable",
         config={"external_hostname": "some_hostname"},
     )
     await ops_test.model.deploy(
         TRAEFIK_CHARM,
         application_name=TRAEFIK_ADMIN_APP,
         trust=True,
-        channel="latest/edge",
+        channel="latest/stable",
         config={"external_hostname": "some_hostname"},
     )
     await ops_test.model.integrate(f"{KRATOS_APP}:internal-ingress", TRAEFIK_ADMIN_APP)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2425,6 +2425,8 @@ def test_on_pebble_ready_with_bad_config(harness: Harness) -> None:
 
 def test_on_config_changed_with_invalid_log_level(harness: Harness) -> None:
     setup_postgres_relation(harness)
+    setup_ingress_relation(harness, "public")
+
     harness.update_config({"log_level": "invalid_config"})
 
     assert isinstance(harness.model.unit.status, BlockedStatus)
@@ -2466,10 +2468,12 @@ def test_kratos_info_ready_event_emitted_when_relation_created(harness: Harness)
 def test_kratos_info_updated_on_relation_ready(harness: Harness) -> None:
     harness.charm.info_provider.send_info_relation_data = mocked_handle = Mock(return_value=None)
     _ = setup_kratos_info_relation(harness)
+    setup_ingress_relation(harness, "public")
 
     mocked_handle.assert_called_with(
         "http://kratos.kratos-model.svc.cluster.local:4434",
         "http://kratos.kratos-model.svc.cluster.local:4433",
+        "https://public/kratos-model-kratos",
         "providers",
         "identity-schemas",
         "kratos-model",
@@ -2517,6 +2521,7 @@ def test_on_pebble_ready_correct_plan_with_proxy_flags_when_unset(
 def test_kratos_info_updated_on_internal_ingress_relation_joined(harness: Harness) -> None:
     kratos_info_relation_id = setup_kratos_info_relation(harness)
 
+    setup_ingress_relation(harness, "public")
     _ = setup_internal_ingress_relation(harness, "admin")
 
     ingress_url = f"{harness.charm.internal_ingress.scheme}://{harness.charm.internal_ingress.external_host}/{harness.model.name}-{harness.model.app.name}"
@@ -2530,6 +2535,7 @@ def test_kratos_info_updated_on_internal_ingress_relation_joined(harness: Harnes
 def test_kratos_info_updated_on_internal_ingress_relation_changed(harness: Harness) -> None:
     kratos_info_relation_id = setup_kratos_info_relation(harness)
 
+    setup_ingress_relation(harness, "public")
     relation_id = setup_internal_ingress_relation(harness, "admin")
 
     url_change = "new-test.staging.canonical.com"
@@ -2550,6 +2556,7 @@ def test_kratos_info_updated_on_internal_ingress_relation_changed(harness: Harne
 def test_kratos_info_updated_on_internal_ingress_relation_broken(harness: Harness) -> None:
     kratos_info_relation_id = setup_kratos_info_relation(harness)
 
+    setup_ingress_relation(harness, "public")
     relation_id = setup_internal_ingress_relation(harness, "admin")
 
     harness.remove_relation(relation_id)


### PR DESCRIPTION
IAM-1066: addressing redirection issue for oathkeeper charm


closes #267
