### PR TITLE
feat: support oidc webauthn sequencing mode

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -106,6 +106,13 @@ config:
         Enable passwordless authentication via webauthn. Requires `enable_local_idp=True`.
       type: boolean
       default: False
+    enable_oidc_webauthn_sequencing:
+      description: |
+        Enforce setting up a WebAuthn key (e.g. with YubiKey or Google Password Manager on Android)
+        after signing in with an external identity provider. Requires `enable_passwordless_login_method=False`.
+        WARNING: Do not enable this option unless you are sure that this feature applies to your deployment.
+      type: boolean
+      default: False
     identity_schemas:
       description: |
         A mapping of schema_id to identity schemas. For example:
@@ -236,7 +243,7 @@ actions:
         description: The user's email
         type: string
       mfa-type:
-        description: The type of credentials to be removed, one of `totp` or `lookup_secret`.
+        description: The type of credentials to be removed, one of `totp`, `lookup_secret` or `webauthn`.
         type: string
   run-migration:
     description: |

--- a/lib/charms/kratos/v0/kratos_info.py
+++ b/lib/charms/kratos/v0/kratos_info.py
@@ -54,7 +54,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 RELATION_NAME = "kratos-info"
 INTERFACE_NAME = "kratos_info"
@@ -97,6 +97,7 @@ class KratosInfoProvider(Object):
         schemas_configmap_name: str,
         configmaps_namespace: str,
         mfa_enabled: bool,
+        oidc_webauthn_sequencing_enabled: bool,
     ) -> None:
         """Updates relation with endpoints, config and configmaps info."""
         if not self._charm.unit.is_leader():
@@ -114,6 +115,7 @@ class KratosInfoProvider(Object):
             "schemas_configmap_name": schemas_configmap_name,
             "configmaps_namespace": configmaps_namespace,
             "mfa_enabled": str(mfa_enabled),
+            "oidc_webauthn_sequencing_enabled": str(oidc_webauthn_sequencing_enabled),
         }
 
         for relation in relations:

--- a/templates/kratos.yaml.j2
+++ b/templates/kratos.yaml.j2
@@ -8,7 +8,7 @@ identity:
         - id: {{ schema_id }}
           url: '{{ identity_schema }}'
         {%- endfor %}
-{%- if enable_local_idp and enforce_mfa %}
+{%- if enable_oidc_webauthn_sequencing or (enable_local_idp and enforce_mfa) %}
 session:
   whoami:
     required_aal: highest_available
@@ -37,7 +37,7 @@ selfservice:
             ui_url: {{ settings_ui_url }}
             required_aal: highest_available
         {%- endif %}
-        {%- if recovery_ui_url %}
+        {%- if recovery_ui_url and enable_local_idp %}
         recovery:
             enabled: True
             ui_url: {{ recovery_ui_url }}
@@ -57,7 +57,7 @@ selfservice:
     {%- endif %}
     {%- if oidc_providers or recovery_ui_url or enable_local_idp and login_ui_url %}
     methods:
-        {%- if recovery_ui_url %}
+        {%- if recovery_ui_url and enable_local_idp %}
         code:
             enabled: True
         {%- endif %}
@@ -75,20 +75,26 @@ selfservice:
             enabled: True
             config:
                 issuer: Identity Platform
+        {%- endif %}
+        {%- endif %}
+        {%- if enable_oidc_webauthn_sequencing or (enforce_mfa and enable_local_idp) %}
         lookup_secret:
             enabled: True
         {%- endif %}
-        {%- if enable_passwordless_login_method %}
+        {%- if enable_passwordless_login_method or enable_oidc_webauthn_sequencing %}
         webauthn:
             enabled: True
             config:
+                {%- if enable_passwordless_login_method %}
                 passwordless: True
+                {%- else %}
+                passwordless: False
+                {%- endif %}
                 rp:
                     id: {{ domain }}
                     origins:
                         - {{ origin }}
                     display_name: Identity Platform
-        {%- endif %}
         {%- endif %}
         {%- if oidc_providers %}
         oidc:


### PR DESCRIPTION
This PR adds support for authentication factors sequencing:
- updates the `reset-identity-mfa` action to include `webauthn`
- adds a config option `enable_oidc_webauthn_sequencing`
- updates the kratos config template
- updates the `kratos-info` lib to include the mode - adds `oidc_webauthn_sequencing_enabled` to relation data.