### PR TITLE
Set a default return url for webauthn settings

### DIFF
--- a/lib/charms/identity_platform_login_ui_operator/v0/login_ui_endpoints.py
+++ b/lib/charms/identity_platform_login_ui_operator/v0/login_ui_endpoints.py
@@ -52,7 +52,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 RELATION_NAME = "ui-endpoint-info"
 INTERFACE_NAME = "login_ui_endpoints"
@@ -67,6 +67,7 @@ RELATION_KEYS = [
     "post_device_done_url",
     "recovery_url",
     "settings_url",
+    "webauthn_settings_url",
 ]
 
 
@@ -118,6 +119,7 @@ class LoginUIEndpointsProvider(Object):
                 "post_device_done_url": f"{endpoint}/ui/device_complete",
                 "recovery_url": f"{endpoint}/ui/reset_email",
                 "settings_url": f"{endpoint}/ui/reset_password",
+                "webauthn_settings_url": f"{endpoint}/ui/setup_passkey",
             }
         for relation in relations:
             relation.data[self._charm.app].update(endpoint_databag)

--- a/src/charm.py
+++ b/src/charm.py
@@ -521,6 +521,7 @@ class KratosCharm(CharmBase):
             error_ui_url=self._get_login_ui_endpoint_info("error_url"),
             settings_ui_url=self._get_login_ui_endpoint_info("settings_url"),
             recovery_ui_url=self._get_login_ui_endpoint_info("recovery_url"),
+            webauthn_settings_url=self._get_login_ui_endpoint_info("webauthn_settings_url"),
             oidc_providers=oidc_providers,
             available_mappers=self._get_available_mappers,
             oauth2_provider_url=self._get_hydra_endpoint_info(),

--- a/templates/kratos.yaml.j2
+++ b/templates/kratos.yaml.j2
@@ -36,6 +36,11 @@ selfservice:
         settings:
             ui_url: {{ settings_ui_url }}
             required_aal: highest_available
+            {%- if enable_passwordless_login_method or enable_oidc_webauthn_sequencing %}
+            after:
+                webauthn:
+                    default_browser_return_url:  {{ webauthn_settings_url }}
+            {%- endif %}
         {%- endif %}
         {%- if recovery_ui_url and enable_local_idp %}
         recovery:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -119,6 +119,7 @@ def setup_login_ui_relation(harness: Harness) -> tuple[int, dict]:
         "device_verification_url": f"{endpoint}/ui/device_code",
         "post_device_done_url": f"{endpoint}/ui/device_complete",
         "settings_url": f"{endpoint}/ui/settings",
+        "webauthn_settings_url": f"{endpoint}/ui/setup_passkey",
         "recovery_url": f"{endpoint}/ui/recovery",
     }
     harness.update_relation_data(
@@ -1792,6 +1793,11 @@ def test_on_config_changed_when_webauthn_enabled(
                 "settings": {
                     "ui_url": login_databag["settings_url"],
                     "required_aal": "highest_available",
+                    "after": {
+                        "webauthn": {
+                            "default_browser_return_url": login_databag["webauthn_settings_url"],
+                        },
+                    },
                 },
                 "recovery": {
                     "enabled": True,
@@ -1930,6 +1936,11 @@ def test_on_config_changed_when_oidc_webauthn_sequencing_enabled(
                 "settings": {
                     "ui_url": login_databag["settings_url"],
                     "required_aal": "highest_available",
+                    "after": {
+                        "webauthn": {
+                            "default_browser_return_url": login_databag["webauthn_settings_url"],
+                        },
+                    },
                 },
                 "recovery": {
                     "enabled": True,


### PR DESCRIPTION
This PR changes the default return url for webauthn method, so that the user remains on the setup page after removing or adding a key. This will not influence any redirect when setup is enforced during login.
fixes https://github.com/canonical/identity-platform-login-ui/issues/381