### PR TITLE
chore: fetch correct login-ui lib

### DIFF
--- a/lib/charms/identity_platform_login_ui_operator/v0/login_ui_endpoints.py
+++ b/lib/charms/identity_platform_login_ui_operator/v0/login_ui_endpoints.py
@@ -45,14 +45,14 @@ from ops.framework import EventBase, EventSource, Object, ObjectEvents
 from ops.model import TooManyRelatedAppsError
 
 # The unique Charmhub library identifier, never change it
-LIBID = "460ab09e6b874d1c891b67f83586c9a7"
+LIBID = "f59057701b5840849d3cea756af404c6"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 1
 
 RELATION_NAME = "ui-endpoint-info"
 INTERFACE_NAME = "login_ui_endpoints"


### PR DESCRIPTION
Following https://github.com/canonical/identity-platform-login-ui-operator/pull/190, we need to import the lib with the correct `LIBID`.
With this change, `charmcraft fetch-lib` works correctly.