### PR TITLE
IAM-1408: address charm CVEs with setupttools

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -282,6 +282,7 @@ parts:
     charm-binary-python-packages:
       - jsonschema
       - bcrypt
+      - "setuptools>=70.0.0"
     build-packages:
       - rustc
       - cargo

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -266,9 +266,8 @@ actions:
         default: 120
 
 ########################### build ###########################
-base: ubuntu@22.04
 platforms:
-  amd64:
+  ubuntu@22.04:amd64:
 parts:
   schemas:
     plugin: dump


### PR DESCRIPTION
fix CVE-2024-6345
fix CVE-2022-40897

closes #372


```
shipperizer in ~/shipperizer/kratos-operator on ci/identity ● λ secscan-client --batch submit --scanner trivy --type package --format charm ./*ubuntu@22.04-amd64.charm --wait-and-print
Scan request submitted.
Scan request is running.
Scan has succeeded.
Scan request information:
  Started at:        2025-04-01 07:50:40+00:00
  Completed at:      2025-04-01 07:50:48+00:00
  Scanner:           trivy
  Target:            s3://secscan-attachments/edfa447e-62f3-4521-b311-abb8f7791a6f
  Target type:       package
  Target format:     charm
  Target vulnerabilities:

```
