### PR TITLE
fix: explicitly disable unsupported methods

### DIFF
--- a/templates/kratos.yaml.j2
+++ b/templates/kratos.yaml.j2
@@ -84,6 +84,12 @@ selfservice:
     {%- endif %}
     {%- if oidc_providers or recovery_ui_url or enable_local_idp and login_ui_url %}
     methods:
+        profile:
+            enabled: False
+        link:
+            enabled: False
+        passkey:
+            enabled: False
         {%- if recovery_ui_url and enable_local_idp %}
         code:
             enabled: True

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -435,6 +435,15 @@ def test_on_pebble_ready_has_correct_config_when_database_is_created(
                 },
             },
             "methods": {
+                "profile": {
+                    "enabled": False,
+                },
+                "link": {
+                    "enabled": False,
+                },
+                "passkey": {
+                    "enabled": False,
+                },
                 "code": {
                     "enabled": True,
                 },
@@ -754,6 +763,15 @@ def test_on_config_changed_when_local_idp_enabled_mfa_not_enforced(
                 },
             },
             "methods": {
+                "profile": {
+                    "enabled": False,
+                },
+                "link": {
+                    "enabled": False,
+                },
+                "passkey": {
+                    "enabled": False,
+                },
                 "code": {
                     "enabled": True,
                 },
@@ -1047,6 +1065,15 @@ def test_on_client_config_changed_with_ingress(
                 },
             },
             "methods": {
+                "profile": {
+                    "enabled": False,
+                },
+                "link": {
+                    "enabled": False,
+                },
+                "passkey": {
+                    "enabled": False,
+                },
                 "code": {
                     "enabled": True,
                 },
@@ -1178,6 +1205,15 @@ def test_on_client_config_relation_removed_with_ingress(
                 },
             },
             "methods": {
+                "profile": {
+                    "enabled": False,
+                },
+                "link": {
+                    "enabled": False,
+                },
+                "passkey": {
+                    "enabled": False,
+                },
                 "code": {
                     "enabled": True,
                 },
@@ -1285,6 +1321,15 @@ def test_on_client_config_data_removed_with_ingress(
                 },
             },
             "methods": {
+                "profile": {
+                    "enabled": False,
+                },
+                "link": {
+                    "enabled": False,
+                },
+                "passkey": {
+                    "enabled": False,
+                },
                 "code": {
                     "enabled": True,
                 },
@@ -1387,6 +1432,15 @@ def test_on_config_changed_with_hydra(
                 },
             },
             "methods": {
+                "profile": {
+                    "enabled": False,
+                },
+                "link": {
+                    "enabled": False,
+                },
+                "passkey": {
+                    "enabled": False,
+                },
                 "code": {
                     "enabled": True,
                 },
@@ -1491,6 +1545,15 @@ def test_on_config_changed_when_missing_hydra_relation_data(
                 },
             },
             "methods": {
+                "profile": {
+                    "enabled": False,
+                },
+                "link": {
+                    "enabled": False,
+                },
+                "passkey": {
+                    "enabled": False,
+                },
                 "code": {
                     "enabled": True,
                 },
@@ -1714,6 +1777,15 @@ def test_on_config_changed_when_local_idp_disabled(
                 },
             },
             "methods": {
+                "profile": {
+                    "enabled": False,
+                },
+                "link": {
+                    "enabled": False,
+                },
+                "passkey": {
+                    "enabled": False,
+                },
                 "password": {
                     "enabled": False,
                 },
@@ -1812,6 +1884,15 @@ def test_on_config_changed_when_webauthn_enabled(
                 },
             },
             "methods": {
+                "profile": {
+                    "enabled": False,
+                },
+                "link": {
+                    "enabled": False,
+                },
+                "passkey": {
+                    "enabled": False,
+                },
                 "code": {
                     "enabled": True,
                 },
@@ -1955,6 +2036,15 @@ def test_on_config_changed_when_oidc_webauthn_sequencing_enabled(
                 },
             },
             "methods": {
+                "profile": {
+                    "enabled": False,
+                },
+                "link": {
+                    "enabled": False,
+                },
+                "passkey": {
+                    "enabled": False,
+                },
                 "code": {
                     "enabled": True,
                 },


### PR DESCRIPTION
As discovered in https://warthogs.atlassian.net/browse/IAM-1436, the `profile` method is enabled by default, in contrast to what the kratos configuration [reference](https://www.ory.sh/docs/kratos/reference/configuration) states.
After an internal discussion we agreed to disable the method since we don't support profile changes in the UI (and kratos actions use the admin API). Along with `profile` we also disable `passkey` and magic `link` as those methods are not supported either.