### PR TITLE
Add optional flags to provides endpoints

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -77,14 +77,17 @@ provides:
     interface: kratos_info
     description: |
       Provides kratos deployment info to a related application
+    optional: true
   metrics-endpoint:
     interface: prometheus_scrape
     description: |
       Provides application metrics to COS Prometheus instance
+    optional: true
   grafana-dashboard:
     description: |
       Forwards the built-in grafana dashboard(s) for monitoring kratos.
     interface: grafana_dashboard
+    optional: true
 config:
   options:
     http_proxy:


### PR DESCRIPTION
## Issue

Since provides endpoints can be non-optional, can the default value of `optional` is [false](https://canonical-charmcraft.readthedocs-hosted.com/stable/reference/files/charmcraft-yaml-file/#endpoint-role-endpoint-name-optional), these endpoints are assumed non-optional.

## Solution

Set `optional` flag on provides endpoints to indicate correct optionality.
