### PR TITLE
fix: improve the error hint for create-admin-account juju action

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -118,6 +118,7 @@ from constants import (
 )
 from exceptions import (
     ClientRequestError,
+    IdentityAlreadyExistsError,
     IdentityCredentialsNotExistError,
     IdentityNotExistsError,
     IdentitySessionsNotExistError,
@@ -995,6 +996,9 @@ class KratosCharm(CharmBase):
         with HTTPClient(base_url=f"http://127.0.0.1:{KRATOS_ADMIN_PORT}") as client:
             try:
                 identity = client.create_identity(traits, schema_id="admin_v0", password=password)
+            except IdentityAlreadyExistsError:
+                event.fail("The account already exists")
+                return
             except ClientRequestError:
                 event.fail("Failed to create the admin account")
                 return

--- a/src/clients.py
+++ b/src/clients.py
@@ -11,6 +11,7 @@ from typing_extensions import Self, Type
 
 from exceptions import (
     ClientRequestError,
+    IdentityAlreadyExistsError,
     IdentityCredentialsNotExistError,
     IdentityNotExistsError,
     IdentitySessionsNotExistError,
@@ -87,6 +88,11 @@ class HTTPClient:
                 json=identity,
             )
             resp.raise_for_status()
+        except requests.exceptions.HTTPError as err:
+            if err.response.status_code == 409:
+                raise IdentityAlreadyExistsError
+
+            raise ClientRequestError
         except requests.exceptions.RequestException as err:
             raise ClientRequestError from err
 

--- a/src/configs.py
+++ b/src/configs.py
@@ -206,17 +206,11 @@ class IdentitySchemaConfigMap(BaseConfigMap):
 
     name = "identity-schemas"
 
-    def __init__(self, k8s_client: Client, namespace: str, app_name: str):
-        super().__init__(k8s_client, namespace, app_name)
-
 
 class OIDCProviderConfigMap(BaseConfigMap):
     """The ConfigMap contains the OIDC provider configurations."""
 
     name = "oidc-providers"
-
-    def __init__(self, k8s_client: Client, namespace: str, app_name: str):
-        super().__init__(k8s_client, namespace, app_name)
 
     def to_service_configs(self) -> ServiceConfigs:
         if not (providers := self.get()):

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -26,6 +26,10 @@ class TooManyIdentitiesError(ActionError):
     """Error for when an email maps to more than one identity."""
 
 
+class IdentityAlreadyExistsError(ActionError):
+    """Error for when an identity already exists."""
+
+
 class IdentityNotExistsError(ActionError):
     """Error for when an identity does not exist."""
 


### PR DESCRIPTION
This pull request aims to enrich the error hint when users try to create a duplicate account. See comments in https://github.com/canonical/kratos-operator/issues/480