### PR TITLE
test: autouse pytest-asyncio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ show_missing = true
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
+asyncio_mode = "auto"
 
 # Linting and formatting tools configuration
 [tool.codespell]


### PR DESCRIPTION
this avoids the event loop closed errors when running the integration tests