### PR TITLE
ci: add todo-to-issue actions

### DIFF
--- a/.github/workflows/todo_manual.yaml
+++ b/.github/workflows/todo_manual.yaml
@@ -1,0 +1,31 @@
+# This workflow could introduce duplicated issues. Trigger it only when necessary.
+# See https://github.com/alstr/todo-to-issue-action?tab=readme-ov-file#multiple-issues-have-been-created
+name: Manual Scan for TODOs
+run-name: Manual TODO Scan for ${{ inputs.MANUAL_COMMIT_REF }} based on ${{ inputs.MANUAL_BASE_REF || 'previous commit' }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      MANUAL_COMMIT_REF:
+        description: "The SHA of the commit to get the diff for"
+        required: true
+      MANUAL_BASE_REF:
+        description: "By default, the commit entered above is compared to the one directly before it; to go back further, enter an earlier SHA here"
+        required: false
+
+jobs:
+  todo-to-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: TODOs to Issues
+        uses: alstr/todo-to-issue-action@v5
+        env:
+          MANUAL_COMMIT_REF: ${{ inputs.MANUAL_COMMIT_REF }}
+          MANUAL_BASE_REF: ${{ inputs.MANUAL_BASE_REF }}
+        with:
+          IGNORE: "lib/charms/(?!kratos/).*"

--- a/.github/workflows/todo_on_merge.yaml
+++ b/.github/workflows/todo_on_merge.yaml
@@ -1,0 +1,20 @@
+name: TODO Scan After PR Merge
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  todo-to-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: TODOs to Issues
+        uses: alstr/todo-to-issue-action@v5
+        with:
+          IGNORE: "lib/charms/(?!kratos/).*"


### PR DESCRIPTION
This pull request aims to add two GitHub workflows to transfer `TODO` comments in the code base to GitHub issues by using https://github.com/alstr/todo-to-issue-action. This allows us to do some fundamental TODO management. The workflows can

- Create issues whenever there are `TODO` comments introduced in the `main` branch
- Manual scan of `TODO` comments starting from one commit to a base commit

Of course, it's not perfect. See https://github.com/alstr/todo-to-issue-action?tab=readme-ov-file#multiple-issues-have-been-created. However, based on our daily use cases, this should not be a problem. Assuming we don't enable the issue URL injection feature, the worst case would be manually closing some duplicated issues if someone accidentally triggers a manual scan, which covers some TODOs that are already transferred. Furthermore, we could even disable the manual workflow once we've done a full scan of the repository.

Give it a go and see if we like it or not.