### PR TITLE
fix: fix the run-migration action to check container connectivity

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1073,8 +1073,8 @@ class KratosCharm(CharmBase):
         event.set_results(dict_to_action_output(res))
 
     def _on_run_migration_action(self, event: ActionEvent) -> None:
-        if not self._workload_service.is_running():
-            event.fail("Service is not ready. Please re-run the action when the charm is active")
+        if not container_connectivity(self):
+            event.fail("Container is not connected yet")
             return
 
         if not peer_integration_exists(self):
@@ -1101,7 +1101,9 @@ class KratosCharm(CharmBase):
 
     def _get_active_flags(self) -> FeatureFlags:
         feature_flags = []
-        if not (selfservice := self.config_file.get("selfservice")) or not selfservice.get("methods"):
+        if not (selfservice := self.config_file.get("selfservice")) or not selfservice.get(
+            "methods"
+        ):
             return feature_flags
 
         methods = selfservice.get("methods")

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -1013,21 +1013,18 @@ class TestRunMigrationAction:
     def mocked_cli(self, mocker: MockerFixture) -> MagicMock:
         return mocker.patch("charm.CommandLine.migrate")
 
-    def test_when_workload_service_not_running(
+    def test_when_container_not_connected(
         self,
         mocked_cli: MagicMock,
-        mocked_workload_service_running: MagicMock,
         peer_integration: testing.Relation,
     ) -> None:
-        mocked_workload_service_running.return_value = False
-
         ctx = testing.Context(KratosCharm)
-        container = testing.Container(WORKLOAD_CONTAINER, can_connect=True)
+        container = testing.Container(WORKLOAD_CONTAINER, can_connect=False)
         state_in = testing.State(leader=True, containers={container}, relations={peer_integration})
 
         with pytest.raises(
             testing.ActionFailed,
-            match="Service is not ready. Please re-run the action when the charm is active",
+            match="Container is not connected yet",
         ):
             ctx.run(ctx.on.action(name="run-migration"), state_in)
 


### PR DESCRIPTION
This pull request aims to resolve https://github.com/canonical/kratos-operator/issues/566.