### PR TITLE
fix: only leader unit can run the db migration action

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1073,6 +1073,10 @@ class KratosCharm(CharmBase):
         event.set_results(dict_to_action_output(res))
 
     def _on_run_migration_action(self, event: ActionEvent) -> None:
+        if not self.unit.is_leader():
+            event.fail("Only the leader unit can run the database migration")
+            return
+
         if not container_connectivity(self):
             event.fail("Container is not connected yet")
             return

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -22,6 +22,7 @@ from conftest import (
     TRAEFIK_ADMIN_APP,
     TRAEFIK_CHARM,
     TRAEFIK_PUBLIC_APP,
+    integrate_dependencies,
 )
 from httpx import Response
 from juju.application import Application
@@ -29,7 +30,6 @@ from juju.unit import Unit
 from pytest_operator.plugin import OpsTest
 
 from constants import PEER_INTEGRATION_NAME
-from tests.integration.conftest import integrate_dependencies
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This pull request makes only the leader unit run the database migration, which follows the [peer integration permissions](https://documentation.ubuntu.com/juju/3.6/reference/relation/#permissions-around-relation-databags).