### PR TITLE
fix: manage ConfigMaps deletion via OwnerReference to StatefulSet

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -74,7 +74,6 @@ from ops.charm import (
     PebbleReadyEvent,
     RelationBrokenEvent,
     RelationEvent,
-    RemoveEvent,
     UpgradeCharmEvent,
 )
 from ops.model import (
@@ -101,7 +100,6 @@ from configs import (
     IdentitySchemaConfigMap,
     OIDCProviderConfigMap,
     create_configmaps,
-    remove_configmaps,
 )
 from constants import (
     ALLOWED_MFA_CREDENTIAL_TYPES,
@@ -159,7 +157,6 @@ from utils import (
     database_resource_is_created,
     dict_to_action_output,
     external_hostname_is_ready,
-    leader_unit,
     migration_is_ready,
     passwordless_config_is_valid,
     peer_integration_exists,
@@ -283,7 +280,6 @@ class KratosCharm(CharmBase):
         self.framework.observe(
             self.on.kratos_pebble_check_recovered, self._on_pebble_check_recovered
         )
-        self.framework.observe(self.on.remove, self._on_remove)
         self.framework.observe(self.on.upgrade_charm, self._on_upgrade_charm)
         self.framework.observe(self.on.update_status, self._on_update_status)
         self.framework.observe(self.on.collect_unit_status, self._on_collect_status)
@@ -583,14 +579,6 @@ class KratosCharm(CharmBase):
 
     def _on_upgrade_charm(self, event: UpgradeCharmEvent) -> None:
         create_configmaps(
-            k8s_client=self._k8s_client,
-            namespace=self.model.name,
-            app_name=self.app.name,
-        )
-
-    @leader_unit
-    def _on_remove(self, event: RemoveEvent) -> None:
-        remove_configmaps(
             k8s_client=self._k8s_client,
             namespace=self.model.name,
             app_name=self.app.name,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -125,26 +125,6 @@ class TestPebbleReadyEvent:
         )
 
 
-class TestRemoveEvent:
-    def test_when_not_leader_unit(self, mocked_remove_configmaps: MagicMock) -> None:
-        ctx = testing.Context(KratosCharm)
-        container = testing.Container(WORKLOAD_CONTAINER, can_connect=False)
-        state_in = testing.State(leader=False, containers={container})
-
-        ctx.run(ctx.on.remove(), state_in)
-
-        mocked_remove_configmaps.assert_not_called()
-
-    def test_when_event_emitted(self, mocked_remove_configmaps: MagicMock) -> None:
-        ctx = testing.Context(KratosCharm)
-        container = testing.Container(WORKLOAD_CONTAINER, can_connect=False)
-        state_in = testing.State(leader=True, containers={container})
-
-        ctx.run(ctx.on.remove(), state_in)
-
-        mocked_remove_configmaps.assert_called_once()
-
-
 class TestUpgradeCharmEvent:
     def test_when_event_emitted(self, mocked_create_configmaps: MagicMock) -> None:
         ctx = testing.Context(KratosCharm)


### PR DESCRIPTION
fixes https://github.com/canonical/kratos-operator/issues/585
## Issue
As revealed by https://github.com/canonical/kratos-operator/issues/585, we can't rely on the juju remove event to clean up k8s resources because this hook runs on both application removal and unit scale-down.
- Currently we check leadership before resources removal. However, when scaling to 0, the last remaining unit is also the leader.
- Consequently, scaling to 0 triggers the cleanup logic, deleting all ConfigMaps.
- While `kratos-config` ConfigMap is removed in 0.5/edge in favor of env vars, we still remove other resources: `identity-schemas` and `identity-providers`, potentially losing data written by Admin UI.

## Solution
This PR transitions ConfigMap management to use k8s OwnerReferences linked to the StatefulSet:

- ConfigMaps are now created with an ownerReference pointing to the application's StatefulSet.
- Scale Down: The StatefulSet persists (replicas=0), so the Garbage Collector preserves the ConfigMaps.
- Charm Removal: The StatefulSet is deleted, triggering the Garbage Collector to remove the ConfigMaps.
- On upgrade event we create or patch existing configMaps with the ownerRef metadata.

## Testing
```
juju deploy postgresql-k8s --channel 14/stable --trust
juju deploy ./*charm kratos --trust --resource oci-image=$(yq eval '.resources.oci-image.upstream-source' charmcraft.yaml)
juju relate kratos postgresql-k8s

juju scale-application kratos 0
# Verify that the oidc-providers and identity-schemas configmaps were not deleted
kubectl get cm -n <model>
juju scale-application kratos 1
```