### PR TITLE
Add courier service

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -107,6 +107,7 @@ from constants import (
     CERTIFICATE_TRANSFER_INTEGRATION_NAME,
     COOKIE_SECRET_CONTENT_KEY,
     COOKIE_SECRET_LABEL,
+    COURIER_SERVICE,
     DATABASE_INTEGRATION_NAME,
     EMAIL_TEMPLATE_FILE_PATH,
     GRAFANA_DASHBOARD_INTEGRATION_NAME,
@@ -539,6 +540,13 @@ class KratosCharm(CharmBase):
             event.add_status(
                 BlockedStatus(
                     f"Failed to start the service, please check the {WORKLOAD_CONTAINER} container logs"
+                )
+            )
+
+        if can_connect and self._workload_service.is_failing(COURIER_SERVICE):
+            event.add_status(
+                BlockedStatus(
+                    f"Failed to start the courier service, please check the {COURIER_SERVICE} container logs"
                 )
             )
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -465,8 +465,24 @@ class KratosCharm(CharmBase):
 
         try:
             self._pebble_service.plan(self._pebble_layer, self.config_file)
+            self._configure_courier()
         except PebbleServiceError as e:
             logger.error("Failed to start the service, please check the container logs: %s", e)
+
+    def _configure_courier(self) -> None:
+        """Ensures the courier runs as a singleton on the leader."""
+        if not container_connectivity(self):
+            return
+
+        if not self.unit.is_leader():
+            if self._workload_service.is_running(COURIER_SERVICE):
+                logger.info("Unit is not the leader, stopping courier service")
+                self._pebble_service.stop(COURIER_SERVICE)
+            return
+
+        if self._pebble_service.config_changed or not self._workload_service.is_running(COURIER_SERVICE):
+            logger.info("Restarting kratos courier service")
+            self._pebble_service.restart(COURIER_SERVICE)
 
     @cached_property
     def config_file(self) -> ConfigFile:
@@ -543,10 +559,10 @@ class KratosCharm(CharmBase):
                 )
             )
 
-        if can_connect and self._workload_service.is_failing(COURIER_SERVICE):
+        if can_connect and self.unit.is_leader() and self._workload_service.is_failing(COURIER_SERVICE):
             event.add_status(
                 BlockedStatus(
-                    f"Failed to start the courier service, please check the {COURIER_SERVICE} container logs"
+                    f"Failed to start the courier service, please check the '{COURIER_SERVICE}' logs on the workload container"
                 )
             )
 
@@ -573,6 +589,12 @@ class KratosCharm(CharmBase):
 
     def _on_leader_elected(self, event: LeaderElectedEvent) -> None:
         self.unit.status = MaintenanceStatus("Configuring resources")
+
+        # Only the new leader unit receives this event.
+        # Update the peer relation to trigger a RelationChangedEvent on all followers
+        if peer_integration_exists(self):
+            self.peer_data["leader"] = self.unit.name
+
         self._holistic_handler(event)
 
     def _on_kratos_pebble_ready(self, event: PebbleReadyEvent) -> None:

--- a/src/constants.py
+++ b/src/constants.py
@@ -7,6 +7,7 @@ from string import Template
 # Charm constants
 POSTGRESQL_DSN_TEMPLATE = Template("postgres://$username:$password@$endpoint/$database")
 WORKLOAD_SERVICE = "kratos"
+COURIER_SERVICE = "courier"
 WORKLOAD_CONTAINER = "kratos"
 PEBBLE_READY_CHECK_NAME = "ready"
 EMAIL_TEMPLATE_FILE_PATH = Path("/etc/config/templates") / "recovery-body.html.gotmpl"

--- a/src/services.py
+++ b/src/services.py
@@ -141,20 +141,28 @@ class PebbleService:
         self._unit = unit
         self._container = unit.get_container(WORKLOAD_CONTAINER)
         self._layer_dict: LayerDict = PEBBLE_LAYER_DICT
+        self.config_changed = False
 
     def plan(self, layer: Layer, config_file: ConfigFile) -> None:
         self._container.add_layer(WORKLOAD_SERVICE, layer, combine=True)
-
         current_config_file = ConfigFile.from_workload_container(self._container)
+        self.config_changed = config_file != current_config_file
+
         try:
-            if config_file != current_config_file:
+            if self.config_changed:
                 self._container.push(CONFIG_FILE_PATH, config_file.content, make_dirs=True)
                 self._container.restart(WORKLOAD_SERVICE)
-                self._container.restart(COURIER_SERVICE)
             else:
                 self._container.replan()
         except Exception as e:
             raise PebbleServiceError(f"Pebble failed to restart the workload service. Error: {e}")
+
+    def restart(self, name: str = WORKLOAD_SERVICE) -> None:
+        """Restarts the specified pebble service."""
+        try:
+            self._container.restart(name)
+        except Exception as e:
+            raise PebbleServiceError(f"Pebble failed to restart the {name} service. Error: {e}")
 
     def stop(self, name: str = WORKLOAD_SERVICE) -> None:
         """Stops the specified pebble service."""

--- a/src/services.py
+++ b/src/services.py
@@ -13,6 +13,7 @@ from configs import ConfigFile
 from constants import (
     CA_BUNDLE_PATH,
     CONFIG_FILE_PATH,
+    COURIER_SERVICE,
     KRATOS_ADMIN_PORT,
     KRATOS_PUBLIC_PORT,
     PEBBLE_READY_CHECK_NAME,
@@ -33,6 +34,12 @@ PEBBLE_LAYER_DICT = {
             "override": "replace",
             "summary": "entrypoint of the kratos image",
             "command": f"kratos serve all --config {CONFIG_FILE_PATH}",
+            "startup": "disabled",
+        },
+        COURIER_SERVICE: {
+            "override": "replace",
+            "summary": "kratos courier worker",
+            "command": f"kratos courier watch --config {CONFIG_FILE_PATH}",
             "startup": "disabled",
         }
     },
@@ -79,32 +86,39 @@ class WorkloadService:
 
         self._version = version
 
-    def get_service(self) -> Optional[ServiceInfo]:
+    def get_service(self, name: str = WORKLOAD_SERVICE) -> Optional[ServiceInfo]:
+        """Get service by name."""
         try:
-            return self._container.get_service(WORKLOAD_SERVICE)
+            return self._container.get_service(name)
         except (ModelError, ConnectionError) as e:
             logger.error("Failed to get pebble service: %s", e)
+            return None
 
-    def is_running(self) -> bool:
+    def is_running(self, name: str = WORKLOAD_SERVICE) -> bool:
         """Checks whether the service is running."""
-        if not (service := self.get_service()):
+        if not (service := self.get_service(name)):
             return False
 
         if not service.is_running():
             return False
 
-        c = self._container.get_checks().get(PEBBLE_READY_CHECK_NAME)
-        return c.status == CheckStatus.UP
+        if name == WORKLOAD_SERVICE:
+            c = self._container.get_checks().get(PEBBLE_READY_CHECK_NAME)
+            return c.status == CheckStatus.UP
 
-    def is_failing(self) -> bool:
+        return True
+
+    def is_failing(self, name: str = WORKLOAD_SERVICE) -> bool:
         """Checks whether the service has crashed."""
-        if not self.get_service():
+        if not (service := self.get_service(name)):
             return False
 
-        if not (c := self._container.get_checks().get(PEBBLE_READY_CHECK_NAME)):
-            return False
+        # For the kratos service, we take into account the pebble ready check
+        if name == WORKLOAD_SERVICE:
+            if c := self._container.get_checks().get(PEBBLE_READY_CHECK_NAME):
+                return c.failures > 0
 
-        return c.failures > 0
+        return not service.is_running()
 
     def open_ports(self) -> None:
         self._unit.open_port(protocol="tcp", port=KRATOS_PUBLIC_PORT)
@@ -136,16 +150,18 @@ class PebbleService:
             if config_file != current_config_file:
                 self._container.push(CONFIG_FILE_PATH, config_file.content, make_dirs=True)
                 self._container.restart(WORKLOAD_SERVICE)
+                self._container.restart(COURIER_SERVICE)
             else:
                 self._container.replan()
         except Exception as e:
             raise PebbleServiceError(f"Pebble failed to restart the workload service. Error: {e}")
 
-    def stop(self) -> None:
+    def stop(self, name: str = WORKLOAD_SERVICE) -> None:
+        """Stops the specified pebble service."""
         try:
-            self._container.stop(WORKLOAD_SERVICE)
+            self._container.stop(name)
         except Exception as e:
-            raise PebbleServiceError(f"Pebble failed to stop the workload service. Error: {e}")
+            raise PebbleServiceError(f"Pebble failed to stop the {name} service. Error: {e}")
 
     def render_pebble_layer(self, *env_var_sources: EnvVarConvertible) -> Layer:
         updated_env_vars = ChainMap(*(source.to_env_vars() for source in env_var_sources))  # type: ignore
@@ -154,5 +170,6 @@ class PebbleService:
             **updated_env_vars,
         }
         self._layer_dict["services"][WORKLOAD_SERVICE]["environment"] = env_vars
+        self._layer_dict["services"][COURIER_SERVICE]["environment"] = env_vars
 
         return Layer(self._layer_dict)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,6 +10,7 @@ from scenario import TCPPort
 
 from charm import KratosCharm
 from constants import (
+    COURIER_SERVICE,
     KRATOS_ADMIN_PORT,
     KRATOS_PUBLIC_PORT,
     PEER_INTEGRATION_NAME,
@@ -738,3 +739,57 @@ class TestTracingEndpointRemovedEvent:
             ctx.run(ctx.on.relation_broken(tracing_integration), state_in)
 
         mocked_charm_holistic_handler.assert_called_once()
+
+
+class TestCourierProcess:
+    @patch("charm.PebbleService.stop")
+    def test_follower_stops_courier_process(
+        self,
+        mocked_pebble_stop: MagicMock,
+        mocked_workload_service_running: MagicMock,
+        mocked_charm_holistic_handler: MagicMock,
+    ) -> None:
+        ctx = testing.Context(KratosCharm)
+        container = testing.Container(WORKLOAD_CONTAINER, can_connect=True)
+        state_in = testing.State(leader=False, containers={container})
+
+        with ctx(ctx.on.update_status(), state_in) as manager:
+            manager.charm._configure_courier()
+
+        mocked_pebble_stop.assert_called_once_with(COURIER_SERVICE)
+
+    @patch("charm.PebbleService.restart")
+    @patch("charm.WorkloadService.is_running", return_value=False)
+    def test_leader_runs_courier(
+        self,
+        mocked_pebble_restart: MagicMock,
+        mocked_charm_holistic_handler: MagicMock,
+    ) -> None:
+        ctx = testing.Context(KratosCharm)
+        container = testing.Container(WORKLOAD_CONTAINER, can_connect=True)
+        state_in = testing.State(leader=True, containers={container})
+
+        with ctx(ctx.on.update_status(), state_in) as manager:
+            manager.charm._pebble_service.config_changed = False
+            manager.charm._configure_courier()
+
+        mocked_pebble_restart.assert_called_once_with(COURIER_SERVICE)
+
+    def test_peer_relation_updated_on_leader_elected(
+        self,
+        mocked_charm_holistic_handler: MagicMock,
+        peer_integration: testing.PeerRelation,
+    ) -> None:
+        """Test that the new leader writes its unit name to the peer relation to notify followers."""
+        ctx = testing.Context(KratosCharm)
+        container = testing.Container(WORKLOAD_CONTAINER, can_connect=True)
+        state_in = testing.State(
+            leader=True,
+            containers={container},
+            relations=[peer_integration],
+        )
+
+        state_out = ctx.run(ctx.on.leader_elected(), state_in)
+        peer_rel_out = state_out.get_relations(PEER_INTEGRATION_NAME)[0]
+
+        assert peer_rel_out.local_app_data["leader"] == json.dumps("kratos/0")

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from ops import ModelError
+from ops.pebble import CheckStatus
 from pytest_mock import MockerFixture
 from scenario import CheckInfo
 
@@ -13,6 +14,7 @@ from configs import ConfigFile
 from constants import (
     CA_BUNDLE_PATH,
     CONFIG_FILE_PATH,
+    COURIER_SERVICE,
     KRATOS_ADMIN_PORT,
     KRATOS_PUBLIC_PORT,
     WORKLOAD_SERVICE,
@@ -61,20 +63,47 @@ class TestWorkloadService:
         mocked_unit.set_workload_version.assert_called_once_with("v1.0.0")
         assert f"Failed to set workload version: {error_msg}" in caplog.text
 
-    def test_is_running(
+    def test_is_running_workload_service_up(
         self, mocked_container: MagicMock, workload_service: WorkloadService
     ) -> None:
-        mocked_service_info = MagicMock(is_running=MagicMock(return_value=True))
-        check = CheckInfo(name="ready")
+        mocked_service_info = MagicMock()
+        mocked_service_info.is_running.return_value = True
+
+        # Mock CheckInfo returning UP
+        check = CheckInfo(name="ready", status=CheckStatus.UP)
         mocked_container.get_checks.return_value = {"ready": check}
 
         with patch.object(
             mocked_container, "get_service", return_value=mocked_service_info
         ) as get_service:
-            is_running = workload_service.is_running()
+            is_running = workload_service.is_running(WORKLOAD_SERVICE)
 
         assert is_running is True
         get_service.assert_called_once_with(WORKLOAD_SERVICE)
+
+    def test_is_running_courier_service(
+        self, mocked_container: MagicMock, workload_service: WorkloadService
+    ) -> None:
+        mocked_service_info = MagicMock()
+        mocked_service_info.is_running.return_value = True
+
+        with patch.object(
+            mocked_container, "get_service", return_value=mocked_service_info
+        ) as get_service:
+            # Courier does not rely on Pebble HTTP checks
+            is_running = workload_service.is_running(COURIER_SERVICE)
+
+        assert is_running is True
+        get_service.assert_called_once_with(COURIER_SERVICE)
+
+    def test_is_running_service_stopped(
+        self, mocked_container: MagicMock, workload_service: WorkloadService
+    ) -> None:
+        mocked_service_info = MagicMock()
+        mocked_service_info.is_running.return_value = False
+
+        with patch.object(mocked_container, "get_service", return_value=mocked_service_info):
+            assert workload_service.is_running(COURIER_SERVICE) is False
 
     def test_is_running_with_error(
         self, mocked_container: MagicMock, workload_service: WorkloadService
@@ -83,6 +112,27 @@ class TestWorkloadService:
             is_running = workload_service.is_running()
 
         assert is_running is False
+
+    def test_is_failing_workload_service_with_check_failures(
+        self, mocked_container: MagicMock, workload_service: WorkloadService
+    ) -> None:
+        mocked_service_info = MagicMock()
+        mocked_container.get_service.return_value = mocked_service_info
+
+        # Mock CheckInfo having failures
+        check = CheckInfo(name="ready", failures=3)
+        mocked_container.get_checks.return_value = {"ready": check}
+
+        assert workload_service.is_failing(WORKLOAD_SERVICE) is True
+
+    def test_is_failing_courier_service_not_running(
+        self, mocked_container: MagicMock, workload_service: WorkloadService
+    ) -> None:
+        mocked_service_info = MagicMock()
+        mocked_service_info.is_running.return_value = False
+        mocked_container.get_service.return_value = mocked_service_info
+
+        assert workload_service.is_failing(COURIER_SERVICE) is True
 
     def test_open_ports(self, mocked_unit: MagicMock, workload_service: WorkloadService) -> None:
         workload_service.open_ports()
@@ -120,13 +170,15 @@ class TestPebbleService:
     ) -> None:
         pebble_service.plan(mocked_layer, config_file=ConfigFile("new_config_file"))
 
+        assert pebble_service.config_changed is True
+
         mocked_container.add_layer.assert_called_once_with(
             WORKLOAD_SERVICE, mocked_layer, combine=True
         )
         mocked_container.push.assert_called_once_with(
             CONFIG_FILE_PATH, "new_config_file", make_dirs=True
         )
-        mocked_container.restart.assert_called_once()
+        mocked_container.restart.assert_called_once_with(WORKLOAD_SERVICE)
         mocked_container.replan.assert_not_called()
 
     @patch("ops.pebble.Layer")
@@ -138,6 +190,8 @@ class TestPebbleService:
         pebble_service: PebbleService,
     ) -> None:
         pebble_service.plan(mocked_layer, config_file=ConfigFile("config_file"))
+
+        assert pebble_service.config_changed is False
 
         mocked_container.add_layer.assert_called_once_with(
             WORKLOAD_SERVICE, mocked_layer, combine=True
@@ -155,15 +209,40 @@ class TestPebbleService:
         pebble_service: PebbleService,
     ) -> None:
         with (
-            patch.object(mocked_container, "replan", side_effect=Exception) as replan,
-            pytest.raises(PebbleServiceError),
+            patch.object(mocked_container, "replan", side_effect=Exception("plan_error")),
+            pytest.raises(PebbleServiceError) as exc_info,
         ):
             pebble_service.plan(mocked_layer, config_file=ConfigFile("config_file"))
 
         mocked_container.add_layer.assert_called_once_with(
             WORKLOAD_SERVICE, mocked_layer, combine=True
         )
-        replan.assert_called_once()
+        assert "Pebble failed to restart the workload service" in str(exc_info.value)
+        assert "plan_error" in str(exc_info.value)
+
+    def test_restart_success(self, mocked_container: MagicMock, pebble_service: PebbleService) -> None:
+        pebble_service.restart(COURIER_SERVICE)
+        mocked_container.restart.assert_called_once_with(COURIER_SERVICE)
+
+    def test_restart_failure(self, mocked_container: MagicMock, pebble_service: PebbleService) -> None:
+        mocked_container.restart.side_effect = Exception("restart_error")
+
+        with pytest.raises(PebbleServiceError) as exc_info:
+            pebble_service.restart(COURIER_SERVICE)
+
+        assert f"Pebble failed to restart the {COURIER_SERVICE} service" in str(exc_info.value)
+
+    def test_stop_success(self, mocked_container: MagicMock, pebble_service: PebbleService) -> None:
+        pebble_service.stop(COURIER_SERVICE)
+        mocked_container.stop.assert_called_once_with(COURIER_SERVICE)
+
+    def test_stop_failure(self, mocked_container: MagicMock, pebble_service: PebbleService) -> None:
+        mocked_container.stop.side_effect = Exception("stop_error")
+
+        with pytest.raises(PebbleServiceError) as exc_info:
+            pebble_service.stop(COURIER_SERVICE)
+
+        assert f"Pebble failed to stop the {COURIER_SERVICE} service" in str(exc_info.value)
 
     def test_render_pebble_layer(self, pebble_service: PebbleService) -> None:
         data_source = MagicMock(spec=EnvVarConvertible)
@@ -181,4 +260,7 @@ class TestPebbleService:
         layer = pebble_service.render_pebble_layer(data_source, another_data_source)
 
         layer_dict = layer.to_dict()
+
+        # Verify both services get the same environment variables
         assert layer_dict["services"][WORKLOAD_SERVICE]["environment"] == expected_env_vars
+        assert layer_dict["services"][COURIER_SERVICE]["environment"] == expected_env_vars


### PR DESCRIPTION
Kratos requires a courier service to be able to send emails. This PR adds it to the pebble layer.

The courier service polls the database for pending outgoing emails. When it reaches 6 attempts the message becomes 'abandoned' (e.g. when it can't reach the smtp server). If the courier service is not running, the messages are in 'queued' status. This is an example of a successfully sent message:
```
curl :4434/admin/courier/messages
[{"id":"d6e83945-f0fc-4554-98b6-3ecdf4e692cd","status":"sent","type":"email","recipient":"<redacted>","body":"\u003credacted-unless-dev-mode\u003e","subject":"Use code <redacted> to verify your account","template_type":"verification_code_valid","channel":"email","send_count":1,"created_at":"2026-04-21T10:21:19.851386Z","updated_at":"2026-04-21T10:21:19.851386Z"}]
```

As discussed on the daily there will be a single instance of courier run by the leader. When the leader changes, the previous one will stop the service and the new leader unit will start it. 

```
$ juju ssh kratos/0      // leader
# PEBBLE_SOCKET=/charm/containers/kratos/pebble.socket /charm/bin/pebble services
Service  Startup   Current  Since
courier  disabled  active   yesterday at 19:15 UTC
kratos   disabled  active   yesterday at 19:15 UTC
 
$ juju ssh kratos/1      // follower
# PEBBLE_SOCKET=/charm/containers/kratos/pebble.socket /charm/bin/pebble services
Service  Startup   Current   Since
courier  disabled  inactive  -
kratos   disabled  active    yesterday at 19:16 UTC
```

Reference: https://www.ory.com/docs/kratos/self-hosted/mail-courier-selfhosted#multi-instance-setup