### PR TITLE
Add verification email to templates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,22 @@ tox devenv
 source venv/bin/activate
 ```
 
+### Verification email template
+
+If the verification email template was changed, a new revision has to be uploaded to the store:
+
+```
+charmcraft upload-resource kratos verification-email-template --filepath=./templates/verification-email-template.gotmpl
+```
+
+The charming [action](https://github.com/canonical/charming-actions/tree/main/upload-charm#files) uploads the most recent resource to the charm release.
+It can also be uploaded manually with:
+
+```
+charmcraft release kratos --revision=<rev> --channel=<channel> --resource=verification-email-template:1
+```
+
+
 ## Testing
 
 ```shell
@@ -62,7 +78,7 @@ juju add-model dev
 # Enable DEBUG logging
 juju model-config logging-config="<root>=INFO;unit=DEBUG"
 # Deploy the charm
-juju deploy ./kratos_ubuntu-*-amd64.charm --resource oci-image=$(yq eval '.resources.oci-image.upstream-source' charmcraft.yaml)
+juju deploy ./kratos_ubuntu-*-amd64.charm --resource oci-image=$(yq eval '.resources.oci-image.upstream-source' charmcraft.yaml) --resource verification-email-template=./templates/verification-email-template.gotmpl --trust
 ```
 
 ## Canonical Contributor Agreement

--- a/src/configs.py
+++ b/src/configs.py
@@ -24,6 +24,7 @@ from typing_extensions import Self
 
 from constants import (
     CONFIG_FILE_PATH,
+    COURIER_TEMPLATE_OVERRIDE_PATH,
     DEFAULT_SCHEMA_ID_FILE_NAME,
     EMAIL_TEMPLATE_FILE_PATH,
     IDENTITY_SCHEMAS_LOCAL_DIR_PATH,
@@ -108,6 +109,7 @@ class CharmConfig:
             "HTTP_PROXY": self._config["http_proxy"],
             "HTTPS_PROXY": self._config["https_proxy"],
             "NO_PROXY": self._config["no_proxy"],
+            "COURIER_TEMPLATE_OVERRIDE_PATH": COURIER_TEMPLATE_OVERRIDE_PATH,
             "COURIER_SMTP_FROM_ADDRESS": self._config["sender_email"],
             "COURIER_SMTP_FROM_NAME": self._config["sender_name"],
         }

--- a/src/constants.py
+++ b/src/constants.py
@@ -8,6 +8,7 @@ from string import Template
 POSTGRESQL_DSN_TEMPLATE = Template("postgres://$username:$password@$endpoint/$database")
 WORKLOAD_SERVICE = "kratos"
 COURIER_SERVICE = "courier"
+COURIER_TEMPLATE_OVERRIDE_PATH = "/etc/config/templates"
 WORKLOAD_CONTAINER = "kratos"
 PEBBLE_READY_CHECK_NAME = "ready"
 EMAIL_TEMPLATE_FILE_PATH = Path("/etc/config/templates") / "recovery-body.html.gotmpl"

--- a/templates/verification-email-template.gotmpl
+++ b/templates/verification-email-template.gotmpl
@@ -1,0 +1,251 @@
+<!doctype html>
+<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml"
+>
+<head><title></title>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <style type="text/css">
+        @media only screen and (min-width:480px) {
+            .mj-column-per-30 {
+                width: 30% !important;
+                max-width: 30%;
+            }
+            .mj-column-per-70 {
+                width: 70% !important;
+                max-width: 70%;
+            }
+        }
+    </style>
+</head>
+<body>
+<div style="word-spacing:normal;background-color:#f3f4f8;margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%">
+<div style="display:none;font-size:1px;color:#fff;line-height:1px;max-height:0;max-width:0;opacity:0;overflow:hidden">
+    Verify your account
+</div>
+<div aria-roledescription="email" style="background-color:#f3f4f8" role="article" lang="und" dir="auto">
+    <div style="margin:0 auto;max-width:600px">
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+            <tbody>
+            <tr>
+                <td style="direction:ltr;font-size:0;padding:32px;text-align:center;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+                    <div style="background:#242424;background-color:#242424;margin:0 auto;max-width:536px">
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                               style="background:#242424;background-color:#242424;width:100%;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+                            <tbody>
+                            <tr>
+                                <td style="direction:ltr;font-size:0;padding:0 0 18px 32px;text-align:center;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+                                    <div class="mj-column-per-100 mj-outlook-group-fix"
+                                         style="font-size:0;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%">
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                               style="vertical-align:top;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0" width="100%">
+                                            <tbody>
+                                            <tr>
+                                                <td align="left" style="font-size:0;padding:0;word-break:break-word;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+                                                    <table border="0" cellpadding="0" cellspacing="0"
+                                                           role="presentation"
+                                                           style="border-collapse:collapse;border-spacing:0;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+                                                        <tbody>
+                                                        <tr>
+                                                            <td style="width:130px;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0"><img alt="Canonical"
+                                                                                         src="https://assets.ubuntu.com/v1/cbe904ec-canonical.jpg"
+                                                                                         style="border:0;display:block;outline:0;text-decoration:none;height:auto;width:100%;font-size:16px;line-height:100%;-ms-interpolation-mode:bicubic"
+                                                                                         width="130" height="auto"></td>
+                                                        </tr>
+                                                        </tbody>
+                                                    </table>
+                                                </td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div style="background:#fff;background-color:#fff;margin:0 auto;max-width:536px">
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                               style="background:#fff;background-color:#fff;width:100%;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+                            <tbody>
+                            <tr>
+                                <td style="direction:ltr;font-size:0;padding:32px;padding-bottom:8px;text-align:center;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+
+                                    <div class="mj-column-per-100 mj-outlook-group-fix"
+                                         style="font-size:0;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%">
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                               style="vertical-align:top;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0" width="100%">
+                                            <tbody>
+                                            <tr>
+                                                <td align="left" style="font-size:0;padding:0;word-break:break-word;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+                                                    <div style="font-family:'Ubuntu variable',Ubuntu,Arial,'libra sans',sans-serif;font-size:24px;font-weight:275;line-height:24px;text-align:left;color:#000">
+                                                        Verify your account
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div style="background:#fff;background-color:#fff;margin:0 auto;max-width:536px">
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                               style="background:#fff;background-color:#fff;width:100%;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+                            <tbody>
+                            <tr>
+                                <td style="direction:ltr;font-size:0;padding:32px;padding-bottom:24px;text-align:center;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+
+                                    <div class="mj-column-per-30 mj-outlook-group-fix"
+                                         style="font-size:0;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:30%;max-width:30%">
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                               width="100%" style="border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+                                            <tbody>
+                                            <tr>
+                                                <td style="vertical-align:top;padding-bottom:8px;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+                                                    <table border="0" cellpadding="0" cellspacing="0"
+                                                           role="presentation" width="100%" style="border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+                                                        <tbody>
+                                                        <tr>
+                                                            <td align="left"
+                                                                style="font-size:0;padding:0;word-break:break-word;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+                                                                <div style="font-family:'Ubuntu variable',Ubuntu,Arial,'libra sans',sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#000">
+                                                                    Account
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        </tbody>
+                                                    </table>
+                                                </td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <div class="mj-column-per-70 mj-outlook-group-fix"
+                                         style="font-size:0;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:70%;max-width:70%">
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                               width="100%" style="border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+                                            <tbody>
+                                            <tr>
+                                                <td style="vertical-align:top;padding-bottom:8px;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+                                                    <table border="0" cellpadding="0" cellspacing="0"
+                                                           role="presentation" width="100%" style="border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+                                                        <tbody>
+                                                        <tr>
+                                                            <td align="left"
+                                                                style="font-size:0;padding:0;word-break:break-word;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+                                                                <div style="font-family:'Ubuntu variable',Ubuntu,Arial,'libra sans',sans-serif;font-size:16px;font-weight:300;line-height:24px;text-align:left;color:#000">
+                                                                    <div style="display:inline-block;word-break:break-all">
+                                                                        {{ .To }}
+                                                                    </div>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                        </tbody>
+                                                    </table>
+                                                </td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div style="background:#fff;background-color:#fff;margin:0 auto;max-width:536px">
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                               style="background:#fff;background-color:#fff;width:100%;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+                            <tbody>
+                            <tr>
+                                <td style="direction:ltr;font-size:0;padding:32px;padding-bottom:12px;padding-top:0;text-align:center;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+
+                                    <div class="mj-column-per-30 mj-outlook-group-fix"
+                                         style="font-size:0;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:30%;max-width:30%">
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                               style="vertical-align:top;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0" width="100%">
+                                            <tbody>
+                                            <tr>
+                                                <td align="left"
+                                                    style="font-size:0;padding:0;padding-bottom:8px;word-break:break-word;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+                                                    <div style="font-family:'Ubuntu variable',Ubuntu,Arial,'libra sans',sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#000">
+                                                        Verification code
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+
+                                    <div class="mj-column-per-70 mj-outlook-group-fix"
+                                         style="font-size:0;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:70%;max-width:70%">
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                               style="vertical-align:top;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0" width="100%">
+                                            <tbody>
+                                            <tr>
+                                                <td align="left"
+                                                    style="font-size:0;padding:0;padding-bottom:8px;word-break:break-word;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+                                                    <div style="font-family:'Ubuntu variable',Ubuntu,Arial,'libra sans',sans-serif;font-size:24px;font-weight:275;line-height:32px;text-align:left;color:#000">
+                                                        {{ .VerificationCode }}
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div style="background:#f7f7f7;background-color:#f7f7f7;margin:0 auto;max-width:536px">
+                        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+                               style="background:#f7f7f7;background-color:#f7f7f7;width:100%;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+                            <tbody>
+                            <tr>
+                                <td style="direction:ltr;font-size:0;padding:32px 24px;text-align:center;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+
+                                    <div class="mj-column-per-100 mj-outlook-group-fix"
+                                         style="font-size:0;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%">
+                                        <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+                                               style="vertical-align:top;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0" width="100%">
+                                            <tbody>
+                                            <tr>
+                                                <td align="left" style="font-size:0;padding:0;word-break:break-word;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+                                                    <div style="font-family:'Ubuntu variable',Ubuntu,Arial,'libra sans',sans-serif;font-size:14px;font-weight:300;line-height:24px;text-align:left;color:#666">
+                                                        You are receiving this email because you are a user of Canonical
+                                                        Identity Platform.
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td align="left" style="font-size:0;padding:0;word-break:break-word;border-collapse:collapse;mso-table-lspace:0;mso-table-rspace:0">
+                                                    <div style="font-family:'Ubuntu variable',Ubuntu,Arial,'libra sans',sans-serif;font-size:14px;font-weight:300;line-height:24px;text-align:left;color:#666">
+                                                        If you're not sure why you're receiving this please contact
+                                                        support.
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+    </div>
+</div>
+</body>
+</html>

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -61,6 +61,7 @@ class TestCharmConfig:
         assert env_vars["HTTP_PROXY"] == "http://proxy"
         assert env_vars["HTTPS_PROXY"] == "https://proxy"
         assert env_vars["NO_PROXY"] == "localhost,127.0.0.1"
+        assert env_vars["COURIER_TEMPLATE_OVERRIDE_PATH"] == "/etc/config/templates"
         assert env_vars["COURIER_SMTP_FROM_ADDRESS"] == "identity@canonical.com"
         assert env_vars["COURIER_SMTP_FROM_NAME"] == "Identity"
         assert "COURIER_TEMPLATES_RECOVERY_CODE_VALID_EMAIL_BODY_HTML" not in env_vars


### PR DESCRIPTION
This PR adds a default verification email template to the templates directory and specifies `COURIER_TEMPLATE_OVERRIDE_PATH`.

fixes https://github.com/canonical/kratos-operator/issues/645