### PR TITLE
fix: explicitly check for pebble service error state

### DIFF
--- a/src/services.py
+++ b/src/services.py
@@ -6,7 +6,7 @@ from collections import ChainMap
 from typing import Optional
 
 from ops import Container, ModelError, Unit
-from ops.pebble import CheckStatus, Layer, LayerDict, ServiceInfo
+from ops.pebble import CheckStatus, Layer, LayerDict, ServiceInfo, ServiceStatus
 
 from cli import CommandLine
 from configs import ConfigFile
@@ -118,7 +118,12 @@ class WorkloadService:
             if c := self._container.get_checks().get(PEBBLE_READY_CHECK_NAME):
                 return c.failures > 0
 
-        return not service.is_running()
+        # Check for explicit pebble service error status
+        if service.current == ServiceStatus.ERROR:
+            return True
+
+        # Service is 'active' or 'inactive'. For 'disabled' services, 'inactive' is a valid state and not a failure
+        return False
 
     def open_ports(self) -> None:
         self._unit.open_port(protocol="tcp", port=KRATOS_PUBLIC_PORT)

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from ops import ModelError
-from ops.pebble import CheckStatus
+from ops.pebble import CheckStatus, ServiceStatus
 from pytest_mock import MockerFixture
 from scenario import CheckInfo
 
@@ -130,6 +130,7 @@ class TestWorkloadService:
     ) -> None:
         mocked_service_info = MagicMock()
         mocked_service_info.is_running.return_value = False
+        mocked_service_info.current = ServiceStatus.ERROR
         mocked_container.get_service.return_value = mocked_service_info
 
         assert workload_service.is_failing(COURIER_SERVICE) is True


### PR DESCRIPTION
This PR updates the `is_failing` method to explicitly check for the pebble [service state](https://documentation.ubuntu.com/ops/latest/reference/pebble/#ops.pebble.ServiceStatus). 
Inactive status does not indicate a failure and it's causing an error on upgrade if the service was previously not running.
