### PR TITLE
Add leader guard to secret_remove

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,5 +22,5 @@ jobs:
     uses: canonical/identity-team/.github/workflows/charm-pull-request.yaml@59d4d2782bcb8fc2deea2aa08442e4c8603f2689 # v1.11.2
     with:
       container-name: "kratos"
-      use-charmcraftcache: true
+      use-charmcraftcache: false
       node-size: large

--- a/.github/workflows/on_schedule.yaml
+++ b/.github/workflows/on_schedule.yaml
@@ -16,4 +16,4 @@ jobs:
     uses: canonical/identity-team/.github/workflows/charm-pull-request.yaml@59d4d2782bcb8fc2deea2aa08442e4c8603f2689 # v1.11.2
     with:
       container-name: "kratos"
-      use-charmcraftcache: true
+      use-charmcraftcache: false

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,7 +31,7 @@ jobs:
     with:
       destination_channel: ${{ inputs.destination_channel}}
       source_branch: ${{ inputs.source_branch}}
-      use-charmcraftcache: true
+      use-charmcraftcache: false
     secrets:
       CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS}}
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -346,8 +346,8 @@ parts:
     plugin: dump
     source: .
     organize:
-      "claim_mappers/**": schemas/
-      "identity_schemas/**": schemas/
+      "claim_mappers/**": schemas/claim_mappers/
+      "identity_schemas/**": schemas/identity_schemas/
     prime:
       - schemas/
   charm:

--- a/lib/charms/kratos/v0/kratos_login_webhook.py
+++ b/lib/charms/kratos/v0/kratos_login_webhook.py
@@ -43,7 +43,7 @@ from pydantic import (
 
 LIBID = "070d0bcbc42042309cc556b43f3f77fd"
 LIBAPI = 0
-LIBPATCH = 1
+LIBPATCH = 2
 
 PYDEPS = ["pydantic"]
 
@@ -199,6 +199,8 @@ class KratosLoginWebhookProvider(Object):
             relation.data[self._charm.app].update(data.model_dump(mode="json", exclude_none=True))
 
     def _delete_juju_secret(self, relation: Relation) -> None:
+        if not self._charm.unit.is_leader():
+            return
         try:
             secret = self.model.get_secret(
                 label=API_KEY_SECRET_LABEL_TEMPLATE.substitute(relation_id=relation.id)

--- a/lib/charms/kratos/v0/kratos_registration_webhook.py
+++ b/lib/charms/kratos/v0/kratos_registration_webhook.py
@@ -43,7 +43,7 @@ from pydantic import (
 
 LIBID = "37ddb4471fae41adb74299f091ee3a28"
 LIBAPI = 0
-LIBPATCH = 5
+LIBPATCH = 6
 
 PYDEPS = ["pydantic"]
 
@@ -197,6 +197,8 @@ class KratosRegistrationWebhookProvider(Object):
             relation.data[self._charm.app].update(data.model_dump(mode="json", exclude_none=True))
 
     def _delete_juju_secret(self, relation: Relation) -> None:
+        if not self._charm.unit.is_leader():
+            return
         try:
             secret = self.model.get_secret(
                 label=API_KEY_SECRET_LABEL_TEMPLATE.substitute(relation_id=relation.id)


### PR DESCRIPTION
For non-leader units the `secret_get` would succeed (as all units can read a secret), but then then the `remove_all_revisions` would raise a `SecretNotFoundError` (as non-leader units do not have permissions to edit the secret).