### PR TITLE
feat: add ci permissions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,6 +24,10 @@ on:
         required: true
         type: boolean
 
+permissions:
+  contents: write
+  issues: write
+
 jobs:
   publish:
     name: Publish Charm


### PR DESCRIPTION
This PR fixes the permissions required to publish a charm